### PR TITLE
Enhance UI with dark theme and gradient animation

### DIFF
--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -44,8 +44,8 @@ describe('Home', () => {
   it('initializes letter statuses to unavailable', () => {
     render(<Home wordList={mockWordList} />);
     // Check a few letters to ensure they are initially unavailable (red background)
-    expect(screen.getByRole('button', { name: 'A' })).toHaveClass('bg-rose-200');
-    expect(screen.getByRole('button', { name: 'Z' })).toHaveClass('bg-rose-200');
+    expect(screen.getByRole('button', { name: 'A' })).toHaveClass('bg-rose-700');
+    expect(screen.getByRole('button', { name: 'Z' })).toHaveClass('bg-rose-700');
   });
 
   it('filters words based on letter status changes', async () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,9 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body>{children}</body>
+      <body className="min-h-screen bg-gradient-to-br from-purple-900 via-gray-900 to-black bg-[length:200%_200%] animate-gradient-slow text-gray-100">
+        {children}
+      </body>
     </html>
   )
 }

--- a/src/components/LetterSelector.test.tsx
+++ b/src/components/LetterSelector.test.tsx
@@ -33,12 +33,12 @@ describe('LetterSelector', () => {
     render(<LetterSelector letterStatuses={initialLetterStatuses} onLetterClick={onLetterClick} />);
 
     // Check 'excluded' (default)
-    expect(screen.getByRole('button', { name: 'A' })).toHaveClass('bg-rose-200', 'text-rose-700');
+    expect(screen.getByRole('button', { name: 'A' })).toHaveClass('bg-rose-700', 'text-rose-100');
 
     // Check 'available'
-    expect(screen.getByRole('button', { name: 'B' })).toHaveClass('bg-blue-200', 'text-blue-700');
+    expect(screen.getByRole('button', { name: 'B' })).toHaveClass('bg-cyan-700', 'text-cyan-100');
 
     // Check 'required-anywhere'
-    expect(screen.getByRole('button', { name: 'C' })).toHaveClass('bg-green-200', 'text-green-700', 'border-b-4');
+    expect(screen.getByRole('button', { name: 'C' })).toHaveClass('bg-lime-600', 'text-lime-100', 'border-b-4');
   });
 });

--- a/src/components/LetterSelector.tsx
+++ b/src/components/LetterSelector.tsx
@@ -13,19 +13,19 @@ const LetterSelector: React.FC<LetterSelectorProps> = ({ letterStatuses, onLette
   return (
     <div className="mb-6 text-center">
       <div className="flex flex-wrap justify-center gap-2 mb-4">
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-blue-200 text-blue-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-cyan-400 bg-cyan-700 text-white">
           Available
         </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-green-200 text-green-700 border-l-4 border-green-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-lime-400 bg-lime-700 text-white border-l-4">
           Required at Start
         </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-green-200 text-green-700 border-b-4 border-green-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-lime-400 bg-lime-600 text-white border-b-4">
           Required anywhere
         </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-green-200 text-green-700 border-r-4 border-green-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-lime-400 bg-lime-700 text-white border-r-4">
           Required at End
         </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-rose-200 text-rose-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-rose-400 bg-rose-700 text-white">
           Excluded
         </span>
       </div>
@@ -35,14 +35,14 @@ const LetterSelector: React.FC<LetterSelectorProps> = ({ letterStatuses, onLette
           const base = 'px-4 py-2 text-lg font-bold rounded transition border';
           const statusClasses =
             status === 'available'
-              ? 'bg-blue-200 text-blue-700 border-blue-400'
+              ? 'bg-cyan-700 text-cyan-100 border-cyan-400'
               : status === 'required-start'
-              ? 'bg-green-200 text-green-700 border-green-400 border-l-4'
+              ? 'bg-lime-700 text-lime-100 border-lime-400 border-l-4'
               : status === 'required-anywhere'
-              ? 'bg-green-200 text-green-700 border-green-400 border-b-4'
+              ? 'bg-lime-600 text-lime-100 border-lime-400 border-b-4'
               : status === 'required-end'
-              ? 'bg-green-200 text-green-700 border-green-400 border-r-4'
-              : 'bg-rose-200 text-rose-700 border-rose-400';
+              ? 'bg-lime-700 text-lime-100 border-lime-400 border-r-4'
+              : 'bg-rose-700 text-rose-100 border-rose-400';
           return (
             <button
               key={char}

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -12,11 +12,11 @@ const WordResults: React.FC<WordResultsProps> = ({
   onSortChange = () => {},
 }) => {
   return (
-    <div className="border-t border-gray-200 pt-5">
+    <div className="border-t border-gray-700 pt-5">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-semibold text-gray-700">Results ({resultCount})</h2>
+        <h2 className="text-2xl font-semibold text-gray-100">Results ({resultCount})</h2>
         <div className="flex items-center space-x-2">
-          <label htmlFor="sortOrder" className="text-sm text-gray-600">Sort:</label>
+          <label htmlFor="sortOrder" className="text-sm text-gray-300">Sort:</label>
           <select
             id="sortOrder"
             onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
@@ -26,7 +26,7 @@ const WordResults: React.FC<WordResultsProps> = ({
                 | 'length-asc'
                 | 'length-desc')
             }
-            className="px-2 py-1 border border-gray-300 rounded-md bg-white text-sm"
+            className="px-2 py-1 border border-gray-600 rounded-md bg-gray-800 text-sm text-gray-100"
           >
             <option value="alphabetical-asc">A-Z</option>
             <option value="alphabetical-desc">Z-A</option>
@@ -40,11 +40,11 @@ const WordResults: React.FC<WordResultsProps> = ({
           No words found for the selected letters.
         </p>
       )}
-      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 max-h-96 overflow-y-auto border border-gray-200 p-2 rounded-md">
+      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 max-h-96 overflow-y-auto border border-gray-700 p-2 rounded-md">
         {results.map((word) => (
           <li
             key={word}
-            className="bg-gray-50 border border-gray-200 rounded-md p-2 text-center shadow-sm"
+            className="bg-gray-800 border border-gray-700 rounded-md p-2 text-center shadow-sm text-gray-100"
           >
             {word}
           </li>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -5,7 +5,17 @@ module.exports = {
     './src/components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        'gradient-move': {
+          '0%, 100%': { backgroundPosition: '0% 50%' },
+          '50%': { backgroundPosition: '100% 50%' },
+        },
+      },
+      animation: {
+        'gradient-slow': 'gradient-move 15s ease infinite',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- enable animated gradient background and dark theme
- restyle letter selector buttons and legend
- apply darker colors to results list
- update tests for new styling

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68699603633c832b997e0e0f2cec490e