### PR TITLE
Add dark theme with animated gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ eg words must start or end with specific letter
 
 ## Display
 
-awesome / cool UI that perhaps looks 3D.
-there might be lots of matching results
+The web UI features a dark theme with an animated gradient background. Result panels use translucent backgrounds so the motion subtly shows through without affecting readability. This colourful style makes the app feel lively while still keeping focus on the puzzle results.
 
 ## Code
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .bg-animated-gradient {
+    @apply bg-gradient-to-br from-purple-900 via-fuchsia-700 to-indigo-900 bg-[length:400%_400%] animate-gradient-x;
+  }
+}
+
+@layer base {
+  body {
+    @apply text-gray-100 bg-gray-900;
+  }
+}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -105,7 +105,7 @@ export default function Home({ wordList }: HomeProps) {
   };
 
   return (
-    <div className="max-w-3xl mx-auto p-4">
+    <div className="max-w-3xl mx-auto p-4 bg-black/50 rounded-lg shadow-lg backdrop-blur-md">
       <header className="flex items-center justify-between mb-6">
         <h1 className="text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-600">
           Letter Unboxed
@@ -113,25 +113,25 @@ export default function Home({ wordList }: HomeProps) {
         <button
           aria-label={showHelp ? 'Close help' : 'Open help'}
           onClick={() => setShowHelp(!showHelp)}
-          className="text-white bg-blue-600 hover:bg-blue-700 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="text-white bg-pink-600 hover:bg-pink-700 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-pink-400"
         >
           ?
         </button>
       </header>
       {showHelp && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-lg mx-4 shadow-lg">
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+          <div className="bg-gray-800 text-gray-100 rounded-lg p-6 max-w-lg mx-4 shadow-lg">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-2xl font-semibold text-gray-800">How to Use</h2>
+              <h2 className="text-2xl font-semibold">How to Use</h2>
               <button
                 aria-label="Close help"
                 onClick={() => setShowHelp(false)}
-                className="text-gray-500 hover:text-gray-700 focus:outline-none"
+                className="text-gray-300 hover:text-white focus:outline-none"
               >
                 &times;
               </button>
             </div>
-            <div className="space-y-2 text-gray-700">
+            <div className="space-y-2 text-gray-200">
               <p>This tool helps you solve Letter Boxed puzzles. Here&apos;s how:</p>
               <ul className="list-disc list-inside">
                 <li>
@@ -156,7 +156,7 @@ export default function Home({ wordList }: HomeProps) {
       )}
       <LetterSelector letterStatuses={letterStatuses} onLetterClick={handleLetterClick} />
       <div className="mb-6 text-center">
-        <label htmlFor="letterGroups" className="mr-2 text-sm font-medium text-gray-700">
+        <label htmlFor="letterGroups" className="mr-2 text-sm font-medium text-gray-200">
           Letter Groups (e.g., abc,def):
         </label>
         <input
@@ -164,7 +164,7 @@ export default function Home({ wordList }: HomeProps) {
           id="letterGroups"
           value={letterGroups}
           onChange={(e) => setLetterGroups(e.target.value.toLowerCase())}
-          className="px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+          className="px-2 py-1 border border-gray-600 bg-gray-700 text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
         />
       </div>
       <WordResults

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body>{children}</body>
+      <body className="min-h-screen bg-animated-gradient">{children}</body>
     </html>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,1 +1,13 @@
-import HomeClient from './home-client';import fs from 'fs';import path from 'path';export default async function Home() {  const filePath = path.join(process.cwd(), 'src', 'dictionary', 'scowl_35.txt');  const wordListContent = fs.readFileSync(filePath, 'utf-8');  const wordList = wordListContent.split('\n').map(word => word.trim()).filter(word => word.length > 0);  return <HomeClient wordList={wordList} />;} 
+import HomeClient from './home-client';
+import fs from 'fs';
+import path from 'path';
+
+export default async function Home() {
+  const filePath = path.join(process.cwd(), 'src', 'dictionary', 'scowl_35.txt');
+  const wordListContent = fs.readFileSync(filePath, 'utf-8');
+  const wordList = wordListContent
+    .split('\n')
+    .map(word => word.trim())
+    .filter(word => word.length > 0);
+  return <HomeClient wordList={wordList} />;
+}

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -12,11 +12,11 @@ const WordResults: React.FC<WordResultsProps> = ({
   onSortChange = () => {},
 }) => {
   return (
-    <div className="border-t border-gray-200 pt-5">
+    <div className="border-t border-gray-700 pt-5">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-semibold text-gray-700">Results ({resultCount})</h2>
+        <h2 className="text-2xl font-semibold text-gray-200">Results ({resultCount})</h2>
         <div className="flex items-center space-x-2">
-          <label htmlFor="sortOrder" className="text-sm text-gray-600">Sort:</label>
+          <label htmlFor="sortOrder" className="text-sm text-gray-300">Sort:</label>
           <select
             id="sortOrder"
             onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
@@ -26,7 +26,7 @@ const WordResults: React.FC<WordResultsProps> = ({
                 | 'length-asc'
                 | 'length-desc')
             }
-            className="px-2 py-1 border border-gray-300 rounded-md bg-white text-sm"
+            className="px-2 py-1 border border-gray-600 bg-gray-700 text-gray-100 rounded-md text-sm"
           >
             <option value="alphabetical-asc">A-Z</option>
             <option value="alphabetical-desc">Z-A</option>
@@ -36,15 +36,15 @@ const WordResults: React.FC<WordResultsProps> = ({
         </div>
       </div>
       {results.length === 0 && (
-        <p className="text-center text-gray-600">
+        <p className="text-center text-gray-300">
           No words found for the selected letters.
         </p>
       )}
-      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 max-h-96 overflow-y-auto border border-gray-200 p-2 rounded-md">
+      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 max-h-96 overflow-y-auto border border-gray-700 p-2 rounded-md">
         {results.map((word) => (
           <li
             key={word}
-            className="bg-gray-50 border border-gray-200 rounded-md p-2 text-center shadow-sm"
+            className="bg-gray-800 border border-gray-700 rounded-md p-2 text-center shadow-sm"
           >
             {word}
           </li>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -5,7 +5,17 @@ module.exports = {
     './src/components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        'gradient-x': {
+          '0%, 100%': { 'background-position': '0% 50%' },
+          '50%': { 'background-position': '100% 50%' },
+        },
+      },
+      animation: {
+        'gradient-x': 'gradient-x 15s ease infinite',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add animated gradient background using Tailwind utilities
- apply dark theme styles in global CSS
- use the new background in layout
- style Home page components for dark mode
- tweak WordResults styling
- document the colourful UI in README

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68699603633c832b997e0e0f2cec490e