### PR TITLE
Implement dark theme with gradient animation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  @keyframes gradient {
+    0%, 100% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+  }
+  .animate-gradient {
+    background-size: 200% 200%;
+    animation: gradient 15s ease infinite;
+  }
+}

--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -44,8 +44,8 @@ describe('Home', () => {
   it('initializes letter statuses to unavailable', () => {
     render(<Home wordList={mockWordList} />);
     // Check a few letters to ensure they are initially unavailable (red background)
-    expect(screen.getByRole('button', { name: 'A' })).toHaveClass('bg-rose-200');
-    expect(screen.getByRole('button', { name: 'Z' })).toHaveClass('bg-rose-200');
+    expect(screen.getByRole('button', { name: 'A' })).toHaveClass('bg-rose-700');
+    expect(screen.getByRole('button', { name: 'Z' })).toHaveClass('bg-rose-700');
   });
 
   it('filters words based on letter status changes', async () => {

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -113,25 +113,25 @@ export default function Home({ wordList }: HomeProps) {
         <button
           aria-label={showHelp ? 'Close help' : 'Open help'}
           onClick={() => setShowHelp(!showHelp)}
-          className="text-white bg-blue-600 hover:bg-blue-700 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="text-white bg-blue-700 hover:bg-blue-600 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-400"
         >
           ?
         </button>
       </header>
       {showHelp && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-lg mx-4 shadow-lg">
+          <div className="bg-gray-900 rounded-lg p-6 max-w-lg mx-4 shadow-lg text-gray-100">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-2xl font-semibold text-gray-800">How to Use</h2>
+              <h2 className="text-2xl font-semibold">How to Use</h2>
               <button
                 aria-label="Close help"
                 onClick={() => setShowHelp(false)}
-                className="text-gray-500 hover:text-gray-700 focus:outline-none"
+                className="text-gray-400 hover:text-gray-200 focus:outline-none"
               >
                 &times;
               </button>
             </div>
-            <div className="space-y-2 text-gray-700">
+            <div className="space-y-2">
               <p>This tool helps you solve Letter Boxed puzzles. Here&apos;s how:</p>
               <ul className="list-disc list-inside">
                 <li>
@@ -156,7 +156,7 @@ export default function Home({ wordList }: HomeProps) {
       )}
       <LetterSelector letterStatuses={letterStatuses} onLetterClick={handleLetterClick} />
       <div className="mb-6 text-center">
-        <label htmlFor="letterGroups" className="mr-2 text-sm font-medium text-gray-700">
+        <label htmlFor="letterGroups" className="mr-2 text-sm font-medium text-gray-200">
           Letter Groups (e.g., abc,def):
         </label>
         <input
@@ -164,7 +164,7 @@ export default function Home({ wordList }: HomeProps) {
           id="letterGroups"
           value={letterGroups}
           onChange={(e) => setLetterGroups(e.target.value.toLowerCase())}
-          className="px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+          className="px-2 py-1 border border-gray-600 rounded-md bg-gray-800 text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
         />
       </div>
       <WordResults

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,9 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body>{children}</body>
+      <body className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 text-gray-100 animate-gradient">
+        {children}
+      </body>
     </html>
   )
 }

--- a/src/components/LetterSelector.test.tsx
+++ b/src/components/LetterSelector.test.tsx
@@ -33,12 +33,12 @@ describe('LetterSelector', () => {
     render(<LetterSelector letterStatuses={initialLetterStatuses} onLetterClick={onLetterClick} />);
 
     // Check 'excluded' (default)
-    expect(screen.getByRole('button', { name: 'A' })).toHaveClass('bg-rose-200', 'text-rose-700');
+    expect(screen.getByRole('button', { name: 'A' })).toHaveClass('bg-rose-700', 'text-white');
 
     // Check 'available'
-    expect(screen.getByRole('button', { name: 'B' })).toHaveClass('bg-blue-200', 'text-blue-700');
+    expect(screen.getByRole('button', { name: 'B' })).toHaveClass('bg-blue-700', 'text-white');
 
     // Check 'required-anywhere'
-    expect(screen.getByRole('button', { name: 'C' })).toHaveClass('bg-green-200', 'text-green-700', 'border-b-4');
+    expect(screen.getByRole('button', { name: 'C' })).toHaveClass('bg-green-700', 'text-white', 'border-b-4');
   });
 });

--- a/src/components/LetterSelector.tsx
+++ b/src/components/LetterSelector.tsx
@@ -13,36 +13,36 @@ const LetterSelector: React.FC<LetterSelectorProps> = ({ letterStatuses, onLette
   return (
     <div className="mb-6 text-center">
       <div className="flex flex-wrap justify-center gap-2 mb-4">
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-blue-200 text-blue-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-blue-500 bg-blue-700 text-white">
           Available
         </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-green-200 text-green-700 border-l-4 border-green-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-green-500 bg-green-700 text-white border-l-4">
           Required at Start
         </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-green-200 text-green-700 border-b-4 border-green-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-green-500 bg-green-700 text-white border-b-4">
           Required anywhere
         </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-green-200 text-green-700 border-r-4 border-green-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-green-500 bg-green-700 text-white border-r-4">
           Required at End
         </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border border-gray-300 bg-rose-200 text-rose-700">
+        <span className="px-3 py-1 text-xs font-bold rounded border border-rose-500 bg-rose-700 text-white">
           Excluded
         </span>
       </div>
       <div className="flex flex-wrap justify-center gap-2">
         {alphabet.map((char) => {
           const status = letterStatuses[char];
-          const base = 'px-4 py-2 text-lg font-bold rounded transition border';
+          const base = 'px-4 py-2 text-lg font-bold rounded transition border transform hover:scale-105';
           const statusClasses =
             status === 'available'
-              ? 'bg-blue-200 text-blue-700 border-blue-400'
+              ? 'bg-blue-700 text-white border-blue-500 hover:bg-blue-600'
               : status === 'required-start'
-              ? 'bg-green-200 text-green-700 border-green-400 border-l-4'
+              ? 'bg-green-700 text-white border-green-500 border-l-4 hover:bg-green-600'
               : status === 'required-anywhere'
-              ? 'bg-green-200 text-green-700 border-green-400 border-b-4'
+              ? 'bg-green-700 text-white border-green-500 border-b-4 hover:bg-green-600'
               : status === 'required-end'
-              ? 'bg-green-200 text-green-700 border-green-400 border-r-4'
-              : 'bg-rose-200 text-rose-700 border-rose-400';
+              ? 'bg-green-700 text-white border-green-500 border-r-4 hover:bg-green-600'
+              : 'bg-rose-700 text-white border-rose-500 hover:bg-rose-600';
           return (
             <button
               key={char}

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -12,11 +12,11 @@ const WordResults: React.FC<WordResultsProps> = ({
   onSortChange = () => {},
 }) => {
   return (
-    <div className="border-t border-gray-200 pt-5">
+    <div className="border-t border-gray-700 pt-5">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-semibold text-gray-700">Results ({resultCount})</h2>
+        <h2 className="text-2xl font-semibold text-gray-200">Results ({resultCount})</h2>
         <div className="flex items-center space-x-2">
-          <label htmlFor="sortOrder" className="text-sm text-gray-600">Sort:</label>
+          <label htmlFor="sortOrder" className="text-sm text-gray-300">Sort:</label>
           <select
             id="sortOrder"
             onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
@@ -26,7 +26,7 @@ const WordResults: React.FC<WordResultsProps> = ({
                 | 'length-asc'
                 | 'length-desc')
             }
-            className="px-2 py-1 border border-gray-300 rounded-md bg-white text-sm"
+            className="px-2 py-1 border border-gray-600 rounded-md bg-gray-800 text-sm text-gray-100"
           >
             <option value="alphabetical-asc">A-Z</option>
             <option value="alphabetical-desc">Z-A</option>
@@ -36,15 +36,15 @@ const WordResults: React.FC<WordResultsProps> = ({
         </div>
       </div>
       {results.length === 0 && (
-        <p className="text-center text-gray-600">
+        <p className="text-center text-gray-300">
           No words found for the selected letters.
         </p>
       )}
-      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 max-h-96 overflow-y-auto border border-gray-200 p-2 rounded-md">
+      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 max-h-96 overflow-y-auto border border-gray-600 p-2 rounded-md bg-gray-800">
         {results.map((word) => (
           <li
             key={word}
-            className="bg-gray-50 border border-gray-200 rounded-md p-2 text-center shadow-sm"
+            className="bg-gray-700 border border-gray-600 rounded-md p-2 text-center shadow-sm text-gray-100"
           >
             {word}
           </li>


### PR DESCRIPTION
## Summary
- style layout with dark gradient background
- animate background gradient via custom CSS
- update word results and letter selector styling
- adjust help dialog and form inputs for dark theme
- update unit tests for new styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68699603633c832b997e0e0f2cec490e