### PR TITLE
Add toggle for letter groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+Use the **Groups** button on the on-screen keyboard to reveal the letter group controls. Press **Letters** to return to the keyboard.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 To build the project for production:

--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -95,4 +95,20 @@ describe('Home', () => {
     // Check if WordResults is rendered (by checking one of its internal elements)
     expect(getByText(/Results \(\d+\)/)).toBeInTheDocument();
   });
+
+  it('toggles letter group controls when Groups and Letters buttons are clicked', () => {
+    render(<Home wordList={mockWordList} />);
+
+    // Groups button should be visible and input hidden initially
+    expect(screen.queryByLabelText(/Letter Groups/)).not.toBeInTheDocument();
+    const groupsButton = screen.getByRole('button', { name: 'Groups' });
+    fireEvent.click(groupsButton);
+    // Now input should be visible and keyboard hidden
+    expect(screen.getByLabelText(/Letter Groups/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'A' })).not.toBeInTheDocument();
+    const lettersButton = screen.getByRole('button', { name: 'Letters' });
+    fireEvent.click(lettersButton);
+    expect(screen.queryByLabelText(/Letter Groups/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'A' })).toBeInTheDocument();
+  });
 });

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -22,6 +22,7 @@ export default function Home({ wordList }: HomeProps) {
   const [results, setResults] = useState<string[]>([]);
   const [showHelp, setShowHelp] = useState<boolean>(false);
   const [letterGroups, setLetterGroups] = useState<string>('');
+  const [showLetterGroups, setShowLetterGroups] = useState<boolean>(false);
   const [sortOrder, setSortOrder] = useState<'alphabetical-asc' | 'alphabetical-desc' | 'length-asc' | 'length-desc'>('length-desc');
   const [dictionary, setDictionary] = useState<Dictionary | null>(null);
 
@@ -142,19 +143,33 @@ export default function Home({ wordList }: HomeProps) {
           </div>
         </div>
       )}
-      <LetterSelector letterStatuses={letterStatuses} onLetterClick={handleLetterClick} />
-      <div className="mb-6 text-center">
-        <label htmlFor="letterGroups" className="mr-2 text-sm font-medium text-gray-700">
-          Letter Groups (e.g., abc,def):
-        </label>
-        <input
-          type="text"
-          id="letterGroups"
-          value={letterGroups}
-          onChange={(e) => setLetterGroups(e.target.value.toLowerCase())}
-          className="px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+      {!showLetterGroups && (
+        <LetterSelector
+          letterStatuses={letterStatuses}
+          onLetterClick={handleLetterClick}
+          onShowGroups={() => setShowLetterGroups(true)}
         />
-      </div>
+      )}
+      {showLetterGroups && (
+        <div className="mb-6 text-center flex items-center justify-center gap-2">
+          <label htmlFor="letterGroups" className="text-sm font-medium text-gray-700">
+            Letter Groups (e.g., abc,def):
+          </label>
+          <input
+            type="text"
+            id="letterGroups"
+            value={letterGroups}
+            onChange={(e) => setLetterGroups(e.target.value.toLowerCase())}
+            className="px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+          <button
+            onClick={() => setShowLetterGroups(false)}
+            className="py-2 px-4 text-sm font-bold rounded border-2 border-gray-700 bg-gray-600 text-gray-300"
+          >
+            Letters
+          </button>
+        </div>
+      )}
       <WordResults
         results={results}
         resultCount={results.length}

--- a/src/components/LetterSelector.test.tsx
+++ b/src/components/LetterSelector.test.tsx
@@ -55,4 +55,20 @@ describe('LetterSelector', () => {
       'text-center'
     );
   });
+
+  it('renders Groups button and fires callback when clicked', () => {
+    const onLetterClick = vi.fn();
+    const onShowGroups = vi.fn();
+    render(
+      <LetterSelector
+        letterStatuses={initialLetterStatuses}
+        onLetterClick={onLetterClick}
+        onShowGroups={onShowGroups}
+      />
+    );
+    const btn = screen.getByRole('button', { name: 'Groups' });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onShowGroups).toHaveBeenCalled();
+  });
 });

--- a/src/components/LetterSelector.tsx
+++ b/src/components/LetterSelector.tsx
@@ -5,10 +5,11 @@ type LetterStatus = 'available' | 'required-start' | 'required-anywhere' | 'requ
 interface LetterSelectorProps {
   letterStatuses: Record<string, LetterStatus>;
   onLetterClick: (char: string) => void;
+  onShowGroups?: () => void;
 }
 
-	const LetterSelector: React.FC<LetterSelectorProps> = ({ letterStatuses, onLetterClick }) => {
-	  const rows = ['qwertyuiop', 'asdfghjkl', 'zxcvbnm'];
+        const LetterSelector: React.FC<LetterSelectorProps> = ({ letterStatuses, onLetterClick, onShowGroups }) => {
+          const rows = ['qwertyuiop', 'asdfghjkl', 'zxcvbnm'];
 
   return (
     <div className="mb-6 text-center">
@@ -29,38 +30,46 @@ interface LetterSelectorProps {
           Excluded
         </span>
       </div>
-	      <div className="space-y-2 w-full max-w-lg mx-auto">
-	        {rows.map((row) => (
-	          <div key={row} className="grid grid-cols-10 gap-1 w-full">
-	            {row.split('').map((char) => {
-	              const status = letterStatuses[char];
-	              const base =
-	                'py-2 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105';
-	              const alignClass =
-	                status === 'required-start'
-	                  ? 'text-left pl-0'
-	                  : status === 'required-end'
-	                  ? 'text-right pr-0'
-	                  : 'text-center';
-	              const statusClasses =
-	                status === 'available'
-	                  ? `bg-gradient-to-br from-blue-500 to-blue-700 text-white border-blue-700 ${alignClass}`
-	                  : status.startsWith('required')
-	                  ? `bg-gradient-to-br from-green-600 to-green-800 text-white border-green-800 ${alignClass}`
-	                  : `bg-gray-600 text-gray-300 border-gray-700 ${alignClass}`;
-	              return (
-	                <button
-	                  key={char}
-	                  onClick={() => onLetterClick(char)}
-	                  className={`${base} ${statusClasses}`}
-	                >
-	                  {char.toUpperCase()}
-	                </button>
-	              );
-	            })}
-	          </div>
-	        ))}
-	      </div>
+              <div className="space-y-2 w-full max-w-lg mx-auto">
+                {rows.map((row, rowIndex) => (
+                  <div key={row} className="grid grid-cols-10 gap-1 w-full">
+                    {row.split('').map((char) => {
+                      const status = letterStatuses[char];
+                      const base =
+                        'py-2 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105';
+                      const alignClass =
+                        status === 'required-start'
+                          ? 'text-left pl-0'
+                          : status === 'required-end'
+                          ? 'text-right pr-0'
+                          : 'text-center';
+                      const statusClasses =
+                        status === 'available'
+                          ? `bg-gradient-to-br from-blue-500 to-blue-700 text-white border-blue-700 ${alignClass}`
+                          : status.startsWith('required')
+                          ? `bg-gradient-to-br from-green-600 to-green-800 text-white border-green-800 ${alignClass}`
+                          : `bg-gray-600 text-gray-300 border-gray-700 ${alignClass}`;
+                      return (
+                        <button
+                          key={char}
+                          onClick={() => onLetterClick(char)}
+                          className={`${base} ${statusClasses}`}
+                        >
+                          {char.toUpperCase()}
+                        </button>
+                      );
+                    })}
+                    {rowIndex === rows.length - 1 && onShowGroups && (
+                      <button
+                        onClick={onShowGroups}
+                        className={`py-2 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105 bg-gray-600 text-gray-300 border-gray-700 col-span-2`}
+                      >
+                        Groups
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a toggle so Letter Groups controls can be shown/hidden
- show `Groups` button on keyboard and `Letters` button next to the input
- update tests for new UI behaviour
- document how to access Letter Groups

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a8eddf45c832baa4158cfbe6c6762