### PR TITLE
Autofill groups from keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-Use the **Groups** button on the on-screen keyboard to reveal the letter group controls. Press **Letters** to return to the keyboard.
+Use the **Groups** button on the on-screen keyboard to reveal the letter group controls. The input will automatically contain all available and required letters, sorted alphabetically and separated by commas. Press **Letters** to return to the keyboard.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -111,4 +111,18 @@ describe('Home', () => {
     expect(screen.queryByLabelText(/Letter Groups/)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'A' })).toBeInTheDocument();
   });
+
+  it('populates letter groups with available and required letters', () => {
+    render(<Home wordList={mockWordList} />);
+
+    // make some letters available/required
+    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('button', { name: 'A' }));
+    fireEvent.click(screen.getByRole('button', { name: 'C' }));
+    fireEvent.click(screen.getByRole('button', { name: 'C' }));
+    fireEvent.click(screen.getByRole('button', { name: 'C' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Groups' }));
+    expect(screen.getByLabelText(/Letter Groups/)).toHaveValue('a,b,c');
+  });
 });

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -105,6 +105,19 @@ export default function Home({ wordList }: HomeProps) {
     setSortOrder(sortOrder);
   };
 
+  const handleShowGroups = () => {
+    const letters = Object.keys(letterStatuses)
+      .filter(
+        (char) =>
+          letterStatuses[char] === 'available' ||
+          letterStatuses[char].startsWith('required')
+      )
+      .sort()
+      .join(',');
+    setLetterGroups(letters);
+    setShowLetterGroups(true);
+  };
+
   return (
     <div className="max-w-3xl mx-auto p-4">
       <header className="flex items-center justify-between mb-6">
@@ -147,7 +160,7 @@ export default function Home({ wordList }: HomeProps) {
         <LetterSelector
           letterStatuses={letterStatuses}
           onLetterClick={handleLetterClick}
-          onShowGroups={() => setShowLetterGroups(true)}
+          onShowGroups={handleShowGroups}
         />
       )}
       {showLetterGroups && (


### PR DESCRIPTION
## Summary
- add auto-fill when switching to letter group input
- document group auto-fill feature
- test group auto-fill behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a95663450832b9478e63930f00f75