### PR TITLE
Refactor Groups view

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-Use the **Groups** button on the on-screen keyboard to reveal the letter group controls. The input will automatically contain all available and required letters, sorted alphabetically and separated by commas. Press **Letters** to return to the keyboard.
+Use the **Groups** button on the on-screen keyboard to switch to group mode. Each selected letter appears in its own group. Press **Letters** to return to the keyboard.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -96,23 +96,23 @@ describe('Home', () => {
     expect(getByText(/Results \(\d+\)/)).toBeInTheDocument();
   });
 
-  it('toggles letter group controls when Groups and Letters buttons are clicked', () => {
+  it('toggles group view when Groups and Letters buttons are clicked', () => {
     render(<Home wordList={mockWordList} />);
 
-    // Groups button should be visible and input hidden initially
-    expect(screen.queryByLabelText(/Letter Groups/)).not.toBeInTheDocument();
+    // Groups button should be visible and group view hidden initially
+    expect(screen.queryByRole('button', { name: 'Letters' })).not.toBeInTheDocument();
     const groupsButton = screen.getByRole('button', { name: 'Groups' });
     fireEvent.click(groupsButton);
-    // Now input should be visible and keyboard hidden
-    expect(screen.getByLabelText(/Letter Groups/)).toBeInTheDocument();
+    // Now group view should show and keyboard hidden
+    expect(screen.getByRole('button', { name: 'Letters' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'A' })).not.toBeInTheDocument();
     const lettersButton = screen.getByRole('button', { name: 'Letters' });
     fireEvent.click(lettersButton);
-    expect(screen.queryByLabelText(/Letter Groups/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Letters' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'A' })).toBeInTheDocument();
   });
 
-  it('populates letter groups with available and required letters', () => {
+  it('shows selected letters as individual groups', () => {
     render(<Home wordList={mockWordList} />);
 
     // make some letters available/required
@@ -123,6 +123,10 @@ describe('Home', () => {
     fireEvent.click(screen.getByRole('button', { name: 'C' }));
 
     fireEvent.click(screen.getByRole('button', { name: 'Groups' }));
-    expect(screen.getByLabelText(/Letter Groups/)).toHaveValue('a,b,c');
+    const letterButtons = screen
+      .getAllByRole('button')
+      .filter(btn => /^[A-Z]$/.test(btn.textContent || ''));
+    const letters = letterButtons.map(btn => btn.textContent);
+    expect(letters).toEqual(['A', 'B', 'C']);
   });
 });

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -4,12 +4,12 @@ import { useState, useEffect } from 'react';
 import { Dictionary } from '../lib/dictionary';
 import LetterSelector from '../components/LetterSelector';
 import WordResults from '../components/WordResults';
+import LetterGroupsDisplay from '../components/LetterGroupsDisplay';
+import type { LetterStatus } from '../components/letterStyles';
 
 interface HomeProps {
   wordList: string[];
 }
-
-type LetterStatus = 'available' | 'required-start' | 'required-anywhere' | 'required-end' | 'excluded';
 
 export default function Home({ wordList }: HomeProps) {
   const [letterStatuses, setLetterStatuses] = useState<Record<string, LetterStatus>>(() => {
@@ -164,24 +164,10 @@ export default function Home({ wordList }: HomeProps) {
         />
       )}
       {showLetterGroups && (
-        <div className="mb-6 text-center flex items-center justify-center gap-2">
-          <label htmlFor="letterGroups" className="text-sm font-medium text-gray-700">
-            Letter Groups (e.g., abc,def):
-          </label>
-          <input
-            type="text"
-            id="letterGroups"
-            value={letterGroups}
-            onChange={(e) => setLetterGroups(e.target.value.toLowerCase())}
-            className="px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
-          />
-          <button
-            onClick={() => setShowLetterGroups(false)}
-            className="py-2 px-4 text-sm font-bold rounded border-2 border-gray-700 bg-gray-600 text-gray-300"
-          >
-            Letters
-          </button>
-        </div>
+        <LetterGroupsDisplay
+          letterStatuses={letterStatuses}
+          onShowLetters={() => setShowLetterGroups(false)}
+        />
       )}
       <WordResults
         results={results}

--- a/src/components/LetterGroupsDisplay.tsx
+++ b/src/components/LetterGroupsDisplay.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { LetterStatus, getLetterButtonClasses } from './letterStyles';
+
+interface LetterGroupsDisplayProps {
+  letterStatuses: Record<string, LetterStatus>;
+  onShowLetters: () => void;
+}
+
+const LetterGroupsDisplay: React.FC<LetterGroupsDisplayProps> = ({ letterStatuses, onShowLetters }) => {
+  const letters = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] !== 'excluded')
+    .sort();
+
+  return (
+    <div className="mb-6 text-center flex flex-wrap justify-center gap-2">
+      {letters.map((char) => (
+        <div key={char} className="p-1 border-2 border-gray-500 rounded">
+          <button
+            aria-label={char.toUpperCase()}
+            className={getLetterButtonClasses(letterStatuses[char], false)}
+            disabled
+          >
+            {char.toUpperCase()}
+          </button>
+        </div>
+      ))}
+      <button
+        onClick={onShowLetters}
+        className="py-2 px-4 text-sm font-bold rounded border-2 border-gray-700 bg-gray-600 text-gray-300"
+      >
+        Letters
+      </button>
+    </div>
+  );
+};
+
+export default LetterGroupsDisplay;

--- a/src/components/LetterSelector.tsx
+++ b/src/components/LetterSelector.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-
-type LetterStatus = 'available' | 'required-start' | 'required-anywhere' | 'required-end' | 'excluded';
+import { LetterStatus, getLetterButtonClasses } from './letterStyles';
 
 interface LetterSelectorProps {
   letterStatuses: Record<string, LetterStatus>;
@@ -35,25 +34,11 @@ interface LetterSelectorProps {
                   <div key={row} className="grid grid-cols-10 gap-1 w-full">
                     {row.split('').map((char) => {
                       const status = letterStatuses[char];
-                      const base =
-                        'py-2 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105';
-                      const alignClass =
-                        status === 'required-start'
-                          ? 'text-left pl-0'
-                          : status === 'required-end'
-                          ? 'text-right pr-0'
-                          : 'text-center';
-                      const statusClasses =
-                        status === 'available'
-                          ? `bg-gradient-to-br from-blue-500 to-blue-700 text-white border-blue-700 ${alignClass}`
-                          : status.startsWith('required')
-                          ? `bg-gradient-to-br from-green-600 to-green-800 text-white border-green-800 ${alignClass}`
-                          : `bg-gray-600 text-gray-300 border-gray-700 ${alignClass}`;
                       return (
                         <button
                           key={char}
                           onClick={() => onLetterClick(char)}
-                          className={`${base} ${statusClasses}`}
+                          className={getLetterButtonClasses(status)}
                         >
                           {char.toUpperCase()}
                         </button>

--- a/src/components/letterStyles.ts
+++ b/src/components/letterStyles.ts
@@ -1,0 +1,18 @@
+export type LetterStatus = 'available' | 'required-start' | 'required-anywhere' | 'required-end' | 'excluded';
+
+export function getLetterButtonClasses(status: LetterStatus, interactive = true): string {
+  const base = `py-2 text-lg font-bold rounded transition border-2 shadow-md${interactive ? ' hover:scale-105' : ''}`;
+  const alignClass =
+    status === 'required-start'
+      ? 'text-left pl-0'
+      : status === 'required-end'
+      ? 'text-right pr-0'
+      : 'text-center';
+  const statusClasses =
+    status === 'available'
+      ? `bg-gradient-to-br from-blue-500 to-blue-700 text-white border-blue-700 ${alignClass}`
+      : status.startsWith('required')
+      ? `bg-gradient-to-br from-green-600 to-green-800 text-white border-green-800 ${alignClass}`
+      : `bg-gray-600 text-gray-300 border-gray-700 ${alignClass}`;
+  return `${base} ${statusClasses}`;
+}


### PR DESCRIPTION
## Summary
- add helper for rendering letter button styles
- show a new `LetterGroupsDisplay` instead of an input when viewing groups
- update Home page to use new component
- document updated Groups feature
- adjust tests for new behaviour

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686a98b4b958832bb740459051f8d094