### PR TITLE
Enhance help overlay and Letters button styling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,12 +106,13 @@ This phase builds on the MVP to add more powerful features and improve the user 
 - [x] Make the questionmark button a circle, not oval
 - [x] Replace "How to use" with "About"
 - [x] Remove copy "This tool helps you solve Letter Boxed puzzles. Here's how:" and replace with
-     "Explore potential Letter Boxed words!
+     "Explore potential Letter Boxed words, find anagrams and learn words that start or end with specific letters.
 
-     Tap letters to cycle through making them available for words, requiring them in words,
-     or excluding them.
+     Tap letters to cycle through modes:
 
-     Github (https://github.com/dave1010/letter-unboxed)"
+     Available, Start, Must contain, End, Excluded.
+
+     Made by Dave (https://dave.engineer) · View code on GitHub (https://github.com/dave1010/letter-unboxed)"
 - [x] Make the red excluded state not so bright. Maybe darker red/grey - almost a disabled state colour.
 - [x] Make the green required state a bit darker, so the white text is more visible.
 - [x] Make the green state border more visible (white) and ensure the letters dont jump as border size changes.

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -133,8 +133,8 @@ export default function Home({ wordList }: HomeProps) {
         </button>
       </header>
       {showHelp && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-lg mx-4 shadow-lg">
+        <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 max-w-lg mx-4 shadow-2xl border border-gray-200">
             <div className="flex items-center justify-between mb-4">
             <h2 className="text-2xl font-semibold text-gray-800">About</h2>
               <button
@@ -145,13 +145,67 @@ export default function Home({ wordList }: HomeProps) {
                 &times;
               </button>
             </div>
-            <div className="space-y-2 text-gray-700">
-              <p>Explore potential Letter Boxed words!</p>
+            <div className="space-y-4 text-gray-700">
               <p>
-                Tap letters to cycle through making them available for words,
-                requiring them in words, or excluding them.
+                Explore potential Letter Boxed words, find anagrams and learn words that start or end with specific letters.
               </p>
-              <p>Github (https://github.com/dave1010/letter-unboxed)</p>
+              <p>Tap letters to cycle through modes:</p>
+              <div className="flex flex-wrap justify-center gap-2">
+                <span className="px-3 py-1 text-xs font-bold rounded border-2 border-blue-700 bg-gradient-to-br from-blue-500 to-blue-700 text-white">
+                  Available
+                </span>
+                <span className="px-3 pl-1 py-1 text-xs font-bold rounded border-2 border-white bg-gradient-to-br from-green-600 to-green-800 text-white">
+                  Start
+                </span>
+                <span className="px-3 py-1 text-xs font-bold rounded border-2 border-white bg-gradient-to-br from-green-600 to-green-800 text-white">
+                  Must contain
+                </span>
+                <span className="px-3 pr-1 py-1 text-xs font-bold rounded border-2 border-white bg-gradient-to-br from-green-600 to-green-800 text-white">
+                  End
+                </span>
+                <span className="px-3 py-1 text-xs font-bold rounded border-2 border-gray-700 bg-gray-600 text-gray-300">
+                  Excluded
+                </span>
+              </div>
+              <p>
+                <a
+                  href="https://dave.engineer"
+                  className="underline text-blue-700"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Made by Dave
+                </a>
+                {' · '}
+                <a
+                  href="https://github.com/dave1010/letter-unboxed"
+                  className="underline text-blue-700"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View code on GitHub
+                </a>
+              </p>
+              <p>
+                <a
+                  href="http://wordlist.aspell.net/"
+                  className="underline text-blue-700"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Word list from SCOWL
+                </a>
+              </p>
+              <p>
+                <a
+                  href="https://www.nytimes.com/puzzles/letter-boxed"
+                  className="underline text-blue-700"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Not affiliated with NYT Letter Boxed
+                </a>
+              </p>
             </div>
           </div>
         </div>

--- a/src/components/LetterGroupsDisplay.test.tsx
+++ b/src/components/LetterGroupsDisplay.test.tsx
@@ -23,6 +23,6 @@ describe('LetterGroupsDisplay', () => {
   it('renders Letters button with large text', () => {
     render(<LetterGroupsDisplay letterStatuses={letterStatuses} onShowLetters={() => {}} />);
     const lettersButton = screen.getByRole('button', { name: 'Letters' });
-    expect(lettersButton).toHaveClass('text-lg');
+    expect(lettersButton).toHaveClass('text-lg', 'px-4');
   });
 });

--- a/src/components/LetterGroupsDisplay.tsx
+++ b/src/components/LetterGroupsDisplay.tsx
@@ -29,7 +29,7 @@ const LetterGroupsDisplay: React.FC<LetterGroupsDisplayProps> = ({ letterStatuse
       ))}
       <button
         onClick={onShowLetters}
-        className="py-2 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105 bg-gray-600 text-gray-300 border-gray-700"
+        className="py-2 px-4 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105 bg-gray-600 text-gray-300 border-gray-700"
       >
         Letters
       </button>

--- a/src/components/LetterSelector.tsx
+++ b/src/components/LetterSelector.tsx
@@ -12,23 +12,6 @@ interface LetterSelectorProps {
 
   return (
     <div className="mb-6 text-center">
-      <div className="flex flex-wrap justify-center gap-2 mb-4">
-        <span className="px-3 py-1 text-xs font-bold rounded border-2 border-blue-700 bg-gradient-to-br from-blue-500 to-blue-700 text-white">
-          Available
-        </span>
-        <span className="px-3 pl-1 py-1 text-xs font-bold rounded border-2 border-white bg-gradient-to-br from-green-600 to-green-800 text-white">
-          Start
-        </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border-2 border-white bg-gradient-to-br from-green-600 to-green-800 text-white">
-          Must contain
-        </span>
-        <span className="px-3 pr-1 py-1 text-xs font-bold rounded border-2 border-white bg-gradient-to-br from-green-600 to-green-800 text-white">
-          End
-        </span>
-        <span className="px-3 py-1 text-xs font-bold rounded border-2 border-gray-700 bg-gray-600 text-gray-300">
-          Excluded
-        </span>
-      </div>
               <div className="space-y-2 w-full max-w-lg mx-auto">
                 {rows.map((row, rowIndex) => (
                   <div key={row} className="grid grid-cols-10 gap-1 w-full">


### PR DESCRIPTION
## Summary
- refine UI for group view switch button with horizontal padding
- move legend into help overlay and refresh help text
- improve help overlay styling and add links
- update README/ROADMAP guidance

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686aa92986c8832ba69b789428964d3c