### PR TITLE
Implement draggable letter groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "letterunbox",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@types/yargs": "^17.0.33",
         "next": "^15.3.5",
         "react": "^19.1.0",
@@ -1895,6 +1896,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cli": "ts-node scripts/cli.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@types/yargs": "^17.0.33",
     "next": "^15.3.5",
     "react": "^19.1.0",

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -220,6 +220,8 @@ export default function Home({ wordList }: HomeProps) {
       {showLetterGroups && (
         <LetterGroupsDisplay
           letterStatuses={letterStatuses}
+          letterGroups={letterGroups}
+          onGroupsChange={setLetterGroups}
           onShowLetters={() => setShowLetterGroups(false)}
         />
       )}

--- a/src/components/LetterGroupsDisplay.test.tsx
+++ b/src/components/LetterGroupsDisplay.test.tsx
@@ -13,6 +13,8 @@ describe('LetterGroupsDisplay', () => {
     render(
       <LetterGroupsDisplay
         letterStatuses={letterStatuses}
+        letterGroups="a,b"
+        onGroupsChange={() => {}}
         onShowLetters={() => {}}
       />
     );
@@ -21,7 +23,14 @@ describe('LetterGroupsDisplay', () => {
   });
 
   it('renders Letters button with large text', () => {
-    render(<LetterGroupsDisplay letterStatuses={letterStatuses} onShowLetters={() => {}} />);
+    render(
+      <LetterGroupsDisplay
+        letterStatuses={letterStatuses}
+        letterGroups="a,b"
+        onGroupsChange={() => {}}
+        onShowLetters={() => {}}
+      />
+    );
     const lettersButton = screen.getByRole('button', { name: 'Letters' });
     expect(lettersButton).toHaveClass('text-lg', 'px-4');
   });

--- a/src/components/LetterGroupsDisplay.tsx
+++ b/src/components/LetterGroupsDisplay.tsx
@@ -1,39 +1,85 @@
 import React from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+  useDroppable,
+  useDraggable,
+} from '@dnd-kit/core';
 import { LetterStatus, getLetterButtonClasses } from './letterStyles';
+import { moveLetter } from '../lib/letterGroups';
 
 interface LetterGroupsDisplayProps {
   letterStatuses: Record<string, LetterStatus>;
+  letterGroups: string;
+  onGroupsChange: (groups: string) => void;
   onShowLetters: () => void;
 }
 
-const LetterGroupsDisplay: React.FC<LetterGroupsDisplayProps> = ({ letterStatuses, onShowLetters }) => {
-  const letters = Object.keys(letterStatuses)
-    .filter((char) => letterStatuses[char] !== 'excluded')
-    .sort();
+function DraggableLetter({ char, groupIndex, status }: { char: string; groupIndex: number; status: LetterStatus }) {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+    id: char,
+    data: { char, groupIndex },
+  });
+  const style = transform ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` } : undefined;
+  return (
+    <button
+      ref={setNodeRef}
+      style={style}
+      aria-label={char.toUpperCase()}
+      className={`${getLetterButtonClasses(status, false)} aspect-square w-12`}
+      disabled
+      {...listeners}
+      {...attributes}
+    >
+      {char.toUpperCase()}
+    </button>
+  );
+}
+
+function LetterGroup({ letters, index, statuses }: { letters: string; index: number; statuses: Record<string, LetterStatus> }) {
+  const { setNodeRef, isOver } = useDroppable({ id: index });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`p-1 border-2 border-gray-500 rounded flex gap-1 min-w-14 ${isOver ? 'bg-gray-700/50' : ''}`}
+    >
+      {letters.split('').map((char) => (
+        <DraggableLetter key={char} char={char} groupIndex={index} status={statuses[char]} />
+      ))}
+    </div>
+  );
+}
+
+const LetterGroupsDisplay: React.FC<LetterGroupsDisplayProps> = ({ letterStatuses, letterGroups, onGroupsChange, onShowLetters }) => {
+  const groups = letterGroups ? letterGroups.split(',').filter(Boolean) : [];
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    const data = active.data.current as { char: string; groupIndex: number } | undefined;
+    if (!data) return;
+    const to = over ? Number(over.id) : null;
+    const updated = moveLetter(groups, data.char, data.groupIndex, to);
+    onGroupsChange(updated.join(','));
+  };
 
   return (
-    <div className="mb-6 text-center flex flex-wrap justify-center gap-2">
-      {letters.map((char) => (
-        <div key={char} className="p-1 border-2 border-gray-500 rounded">
-          <button
-            aria-label={char.toUpperCase()}
-            className={`${getLetterButtonClasses(
-              letterStatuses[char],
-              false
-            )} aspect-square w-12`}
-            disabled
-          >
-            {char.toUpperCase()}
-          </button>
-        </div>
-      ))}
-      <button
-        onClick={onShowLetters}
-        className="py-2 px-4 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105 bg-gray-600 text-gray-300 border-gray-700"
-      >
-        Letters
-      </button>
-    </div>
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <div className="mb-6 text-center flex flex-wrap justify-center gap-2">
+        {groups.map((group, index) => (
+          <LetterGroup key={index} letters={group} index={index} statuses={letterStatuses} />
+        ))}
+        <button
+          onClick={onShowLetters}
+          className="py-2 px-4 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105 bg-gray-600 text-gray-300 border-gray-700"
+        >
+          Letters
+        </button>
+      </div>
+    </DndContext>
   );
 };
 

--- a/src/lib/letterGroups.test.ts
+++ b/src/lib/letterGroups.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { moveLetter } from './letterGroups';
+
+describe('moveLetter', () => {
+  it('moves a letter to another group', () => {
+    const result = moveLetter(['a', 'b', 'c'], 'a', 0, 1);
+    expect(result).toEqual(['ba', 'c']);
+  });
+
+  it('creates new group when dropped outside', () => {
+    const result = moveLetter(['a', 'b', 'c'], 'a', 0, null);
+    expect(result).toEqual(['b', 'c', 'a']);
+  });
+
+  it('removes empty groups', () => {
+    const result = moveLetter(['ab', 'c'], 'a', 0, 1);
+    expect(result).toEqual(['b', 'ca']);
+  });
+});

--- a/src/lib/letterGroups.ts
+++ b/src/lib/letterGroups.ts
@@ -1,0 +1,22 @@
+export function moveLetter(groups: string[], char: string, from: number, to: number | null): string[] {
+  const updated = [...groups];
+  updated[from] = updated[from].replace(char, '');
+  const removed = updated[from] === '';
+  if (removed) {
+    updated.splice(from, 1);
+  }
+  if (to === null) {
+    updated.push(char);
+  } else {
+    let target = to;
+    if (removed && from < to) {
+      target -= 1;
+    }
+    if (target >= updated.length) {
+      updated.push(char);
+    } else {
+      updated[target] = (updated[target] || '') + char;
+    }
+  }
+  return updated;
+}


### PR DESCRIPTION
## Summary
- add `@dnd-kit/core` for drag-and-drop support
- implement `moveLetter` helper for managing letter groups
- display draggable letter groups and update state on drag
- wire groups through `Home` component
- test helper and update component tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ab464a6cc832b8ab6ac771a093462