### PR TITLE
Improve letter grouping UX

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -168,6 +168,9 @@ export default function Home({ wordList }: HomeProps) {
                 </span>
               </div>
               <p>
+                Drag letters into groups to stop them being used consecutively.
+              </p>
+              <p>
                 <a
                   href="https://dave.engineer"
                   className="underline text-blue-700"

--- a/src/lib/letterGroups.test.ts
+++ b/src/lib/letterGroups.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { moveLetter } from './letterGroups';
+import { moveLetter, getInsertionIndex } from './letterGroups';
 
 describe('moveLetter', () => {
   it('moves a letter to another group', () => {
     const result = moveLetter(['a', 'b', 'c'], 'a', 0, 1);
-    expect(result).toEqual(['ba', 'c']);
+    expect(result).toEqual(['ab', 'c']);
   });
 
   it('creates new group when dropped outside', () => {
@@ -14,6 +14,12 @@ describe('moveLetter', () => {
 
   it('removes empty groups', () => {
     const result = moveLetter(['ab', 'c'], 'a', 0, 1);
-    expect(result).toEqual(['b', 'ca']);
+    expect(result).toEqual(['b', 'ac']);
   });
+});
+
+it('calculates insertion index alphabetically', () => {
+  expect(getInsertionIndex('ac', 'b')).toBe(1);
+  expect(getInsertionIndex('ac', 'd')).toBe(2);
+  expect(getInsertionIndex('bd', 'a')).toBe(0);
 });

--- a/src/lib/letterGroups.ts
+++ b/src/lib/letterGroups.ts
@@ -1,4 +1,13 @@
-export function moveLetter(groups: string[], char: string, from: number, to: number | null): string[] {
+function sortLetters(group: string): string {
+  return group.split('').sort().join('');
+}
+
+export function moveLetter(
+  groups: string[],
+  char: string,
+  from: number,
+  to: number | null,
+): string[] {
   const updated = [...groups];
   updated[from] = updated[from].replace(char, '');
   const removed = updated[from] === '';
@@ -18,5 +27,13 @@ export function moveLetter(groups: string[], char: string, from: number, to: num
       updated[target] = (updated[target] || '') + char;
     }
   }
-  return updated;
+  return updated.map(sortLetters);
+}
+
+export function getInsertionIndex(group: string, char: string): number {
+  const letters = group.split('');
+  for (let i = 0; i < letters.length; i++) {
+    if (char < letters[i]) return i;
+  }
+  return letters.length;
 }


### PR DESCRIPTION
## Summary
- keep letters in groups sorted alphabetically
- calculate insertion index to show a gap when dragging over a group
- add DragOverlay and remove sensor delay for more responsive dragging
- highlight droppable groups and show gap placeholder
- note about dragging letters into groups in help overlay
- update tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ad889b3a4832baed5b7acd32084b1