### PR TITLE
Refactor Home logic into utilities

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -7,75 +7,12 @@ import WordResults, { SortOrder } from "../components/WordResults";
 import LetterGroupsDisplay from "../components/LetterGroupsDisplay";
 import type { LetterStatus } from "../components/letterStyles";
 import { encodeState, decodeState } from "../lib/urlState";
-
-const alphabet = "abcdefghijklmnopqrstuvwxyz";
-
-export function createDefaultStatuses(): Record<string, LetterStatus> {
-  const statuses: Record<string, LetterStatus> = {};
-  alphabet.split("").forEach((char) => {
-    statuses[char] = "excluded";
-  });
-  return statuses;
-}
-
-const cycleMap: Record<LetterStatus, LetterStatus> = {
-  excluded: "available",
-  available: "required-start",
-  "required-start": "required-anywhere",
-  "required-anywhere": "required-end",
-  "required-end": "excluded",
-};
-
-export function computeResults(
-  dictionary: Dictionary | null,
-  letterStatuses: Record<string, LetterStatus>,
-  sortOrder: SortOrder,
-  letterGroups: string,
-): string[] {
-  if (!dictionary) return [];
-
-  const availableLetters = Object.keys(letterStatuses)
-    .filter((char) => letterStatuses[char] === "available")
-    .join("");
-  const requiredAnywhere = Object.keys(letterStatuses)
-    .filter((char) => letterStatuses[char] === "required-anywhere")
-    .join("");
-  const requiredStart = Object.keys(letterStatuses)
-    .filter((char) => letterStatuses[char] === "required-start")
-    .join("");
-  const requiredEnd = Object.keys(letterStatuses)
-    .filter((char) => letterStatuses[char] === "required-end")
-    .join("");
-  const excludedLetters = Object.keys(letterStatuses)
-    .filter((char) => letterStatuses[char] === "excluded")
-    .join("");
-
-  const filteredWords = dictionary.filter(
-    availableLetters,
-    requiredAnywhere + requiredStart + requiredEnd,
-    excludedLetters,
-    requiredStart,
-    requiredEnd,
-    letterGroups,
-  );
-
-  const sortedWords = [...filteredWords];
-  switch (sortOrder) {
-    case "alphabetical-asc":
-      sortedWords.sort();
-      break;
-    case "alphabetical-desc":
-      sortedWords.sort().reverse();
-      break;
-    case "length-asc":
-      sortedWords.sort((a, b) => a.length - b.length || a.localeCompare(b));
-      break;
-    case "length-desc":
-      sortedWords.sort((a, b) => b.length - a.length || a.localeCompare(b));
-      break;
-  }
-  return sortedWords.slice(0, 1000);
-}
+import {
+  computeResults,
+  createDefaultStatuses,
+  cycleMap,
+  calculateGroups,
+} from "./home-utils";
 
 interface HomeProps {
   wordList: string[];
@@ -128,36 +65,7 @@ export default function Home({ wordList }: HomeProps) {
   };
 
   const handleShowGroups = () => {
-    const selected = Object.keys(letterStatuses)
-      .filter(
-        (char) =>
-          letterStatuses[char] === "available" ||
-          letterStatuses[char].startsWith("required"),
-      )
-      .sort();
-
-    const selectedSet = new Set(selected);
-    let groups = letterGroups ? letterGroups.split(",").filter(Boolean) : [];
-
-    if (!letterGroups) {
-      groups = selected.map((ch) => ch);
-    } else {
-      groups = groups
-        .map((g) =>
-          g
-            .split("")
-            .filter((ch) => selectedSet.has(ch))
-            .join(""),
-        )
-        .filter((g) => g);
-
-      const grouped = new Set(groups.join(""));
-      selected.forEach((ch) => {
-        if (!grouped.has(ch)) groups.push(ch);
-      });
-    }
-
-    setLetterGroups(groups.join(","));
+    setLetterGroups(calculateGroups(letterStatuses, letterGroups));
     setShowLetterGroups(true);
   };
 

--- a/src/app/home-utils.test.ts
+++ b/src/app/home-utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { Dictionary } from "../lib/dictionary";
+import {
+  createDefaultStatuses,
+  cycleMap,
+  computeResults,
+  calculateGroups,
+} from "./home-utils";
+import type { LetterStatus } from "../components/letterStyles";
+
+describe("home-utils", () => {
+  it("createDefaultStatuses returns all letters excluded", () => {
+    const statuses = createDefaultStatuses();
+    expect(Object.keys(statuses)).toHaveLength(26);
+    for (const status of Object.values(statuses)) {
+      expect(status).toBe("excluded");
+    }
+  });
+
+  it("cycleMap cycles statuses", () => {
+    expect(cycleMap["excluded"]).toBe("available");
+    expect(cycleMap["available"]).toBe("required-start");
+    expect(cycleMap["required-start"]).toBe("required-anywhere");
+    expect(cycleMap["required-anywhere"]).toBe("required-end");
+    expect(cycleMap["required-end"]).toBe("excluded");
+  });
+
+  it("computeResults filters and sorts words", () => {
+    const dict = new Dictionary("cat", "cot", "dog", "cart");
+    const statuses = createDefaultStatuses();
+    statuses.c = "available";
+    statuses.a = "available";
+    statuses.t = "available";
+    statuses.o = "available";
+    const res = computeResults(dict, statuses, "alphabetical-asc", "");
+    expect(res).toEqual(["cat", "cot"]);
+  });
+
+  it("calculateGroups returns expected grouping", () => {
+    const statuses: Record<string, LetterStatus> = createDefaultStatuses();
+    statuses.a = "available";
+    statuses.b = "required-anywhere";
+    let groups = calculateGroups(statuses, "");
+    expect(groups).toBe("a,b");
+
+    statuses.c = "available";
+    groups = calculateGroups(statuses, "ab,cd");
+    expect(groups).toBe("ab,c");
+  });
+});

--- a/src/app/home-utils.ts
+++ b/src/app/home-utils.ts
@@ -1,0 +1,108 @@
+export const alphabet = "abcdefghijklmnopqrstuvwxyz";
+
+import type { LetterStatus } from "../components/letterStyles";
+import type { SortOrder } from "../components/WordResults";
+import { Dictionary } from "../lib/dictionary";
+
+export function createDefaultStatuses(): Record<string, LetterStatus> {
+  const statuses: Record<string, LetterStatus> = {};
+  alphabet.split("").forEach((char) => {
+    statuses[char] = "excluded";
+  });
+  return statuses;
+}
+
+export const cycleMap: Record<LetterStatus, LetterStatus> = {
+  excluded: "available",
+  available: "required-start",
+  "required-start": "required-anywhere",
+  "required-anywhere": "required-end",
+  "required-end": "excluded",
+};
+
+export function computeResults(
+  dictionary: Dictionary | null,
+  letterStatuses: Record<string, LetterStatus>,
+  sortOrder: SortOrder,
+  letterGroups: string,
+): string[] {
+  if (!dictionary) return [];
+
+  const availableLetters = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "available")
+    .join("");
+  const requiredAnywhere = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "required-anywhere")
+    .join("");
+  const requiredStart = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "required-start")
+    .join("");
+  const requiredEnd = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "required-end")
+    .join("");
+  const excludedLetters = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "excluded")
+    .join("");
+
+  const filteredWords = dictionary.filter(
+    availableLetters,
+    requiredAnywhere + requiredStart + requiredEnd,
+    excludedLetters,
+    requiredStart,
+    requiredEnd,
+    letterGroups,
+  );
+
+  const sortedWords = [...filteredWords];
+  switch (sortOrder) {
+    case "alphabetical-asc":
+      sortedWords.sort();
+      break;
+    case "alphabetical-desc":
+      sortedWords.sort().reverse();
+      break;
+    case "length-asc":
+      sortedWords.sort((a, b) => a.length - b.length || a.localeCompare(b));
+      break;
+    case "length-desc":
+      sortedWords.sort((a, b) => b.length - a.length || a.localeCompare(b));
+      break;
+  }
+  return sortedWords.slice(0, 1000);
+}
+
+export function calculateGroups(
+  letterStatuses: Record<string, LetterStatus>,
+  letterGroups: string,
+): string {
+  const selected = Object.keys(letterStatuses)
+    .filter(
+      (char) =>
+        letterStatuses[char] === "available" ||
+        letterStatuses[char].startsWith("required"),
+    )
+    .sort();
+
+  const selectedSet = new Set(selected);
+  let groups = letterGroups ? letterGroups.split(",").filter(Boolean) : [];
+
+  if (!letterGroups) {
+    groups = selected.map((ch) => ch);
+  } else {
+    groups = groups
+      .map((g) =>
+        g
+          .split("")
+          .filter((ch) => selectedSet.has(ch))
+          .join("")
+      )
+      .filter((g) => g);
+
+    const grouped = new Set(groups.join(""));
+    selected.forEach((ch) => {
+      if (!grouped.has(ch)) groups.push(ch);
+    });
+  }
+
+  return groups.join(",");
+}


### PR DESCRIPTION
## Summary
- move letter state logic and results calculation to `home-utils.ts`
- add dedicated tests for the new utility functions
- simplify `Home` by delegating group generation to `calculateGroups`

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b69f45a0c832b9cb3ac65c193d34f