### PR TITLE
Add keyboard toggle-all button

### DIFF
--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -141,6 +141,18 @@ describe("Home", () => {
     expect(letters).toEqual(["A", "B", "C"]);
   });
 
+  it("toggles all letters available and back", () => {
+    render(<Home wordList={mockWordList} />);
+    const toggle = screen.getByRole("button", { name: "Enable all letters" });
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: "Clear all letters" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "A" })).toHaveClass("border-blue-700");
+    const clear = screen.getByRole("button", { name: "Clear all letters" });
+    fireEvent.click(clear);
+    expect(screen.getByRole("button", { name: "Enable all letters" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "A" })).toHaveClass("border-gray-700");
+  });
+
   it("updates URL fragment with current state", async () => {
     render(<Home wordList={mockWordList} />);
     fireEvent.click(screen.getByRole("button", { name: "A" }));

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -23,6 +23,7 @@ export default function Home({ wordList }: HomeProps) {
     Record<string, LetterStatus>
   >(() => createDefaultStatuses());
   const [results, setResults] = useState<string[]>([]);
+  const [enableAllNext, setEnableAllNext] = useState(true);
   const [showHelp, setShowHelp] = useState<boolean>(false);
   const [letterGroups, setLetterGroups] = useState<string>("");
   const [showLetterGroups, setShowLetterGroups] = useState<boolean>(false);
@@ -58,6 +59,17 @@ export default function Home({ wordList }: HomeProps) {
 
   const handleLetterClick = (char: string) => {
     setLetterStatuses((prev) => ({ ...prev, [char]: cycleMap[prev[char]] }));
+  };
+
+  const handleToggleAll = () => {
+    setLetterStatuses((prev) => {
+      const updated: Record<string, LetterStatus> = {};
+      Object.keys(prev).forEach((c) => {
+        updated[c] = enableAllNext ? 'available' : 'excluded';
+      });
+      return updated;
+    });
+    setEnableAllNext(!enableAllNext);
   };
 
   const handleSortChange = (sortOrder: SortOrder) => {
@@ -170,6 +182,8 @@ export default function Home({ wordList }: HomeProps) {
           letterStatuses={letterStatuses}
           onLetterClick={handleLetterClick}
           onShowGroups={handleShowGroups}
+          onToggleAll={handleToggleAll}
+          toggleAllNext={enableAllNext}
         />
       )}
       {showLetterGroups && (

--- a/src/components/LetterSelector.test.tsx
+++ b/src/components/LetterSelector.test.tsx
@@ -71,4 +71,21 @@ describe('LetterSelector', () => {
     fireEvent.click(btn);
     expect(onShowGroups).toHaveBeenCalled();
   });
+
+  it('shows toggle-all button and fires callback when clicked', () => {
+    const onLetterClick = vi.fn();
+    const onToggleAll = vi.fn();
+    render(
+      <LetterSelector
+        letterStatuses={initialLetterStatuses}
+        onLetterClick={onLetterClick}
+        onToggleAll={onToggleAll}
+        toggleAllNext={true}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Enable all letters' });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onToggleAll).toHaveBeenCalled();
+  });
 });

--- a/src/components/LetterSelector.tsx
+++ b/src/components/LetterSelector.tsx
@@ -5,16 +5,36 @@ interface LetterSelectorProps {
   letterStatuses: Record<string, LetterStatus>;
   onLetterClick: (char: string) => void;
   onShowGroups?: () => void;
+  onToggleAll?: () => void;
+  toggleAllNext?: boolean;
 }
 
-        const LetterSelector: React.FC<LetterSelectorProps> = ({ letterStatuses, onLetterClick, onShowGroups }) => {
-          const rows = ['qwertyuiop', 'asdfghjkl', 'zxcvbnm'];
+const LetterSelector: React.FC<LetterSelectorProps> = ({
+  letterStatuses,
+  onLetterClick,
+  onShowGroups,
+  onToggleAll,
+  toggleAllNext,
+}) => {
+  const rows = ['qwertyuiop', 'asdfghjkl', 'zxcvbnm'];
 
   return (
     <div className="mb-6 text-center">
               <div className="space-y-2 w-full max-w-lg mx-auto">
                 {rows.map((row, rowIndex) => (
-                  <div key={row} className="grid grid-cols-10 gap-1 w-full">
+                  <div
+                    key={row}
+                    className={`grid grid-cols-10 gap-1 w-full ${rowIndex === 1 ? 'ml-[5%]' : ''}`}
+                  >
+                    {rowIndex === rows.length - 1 && onToggleAll && (
+                      <button
+                        aria-label={toggleAllNext ? 'Enable all letters' : 'Clear all letters'}
+                        onClick={onToggleAll}
+                        className={getLetterButtonClasses('excluded')}
+                      >
+                        {toggleAllNext ? '🔤' : '🧹'}
+                      </button>
+                    )}
                     {row.split('').map((char) => {
                       const status = letterStatuses[char];
                       return (


### PR DESCRIPTION
## Summary
- add toggle-all and next-state props to `LetterSelector`
- shift the second keyboard row right and add toggle button before Z
- expose toggle logic in `Home`
- test the new behaviours

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686b756e61c4832bb0cbe75c8cbcfb26