### PR TITLE
Update roadmap, readme, and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The Letter Unboxed contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ npm run cli -- solve abcdefghijkl -m a -c z -d src/dictionary/scowl_100.txt
 
 ## Dictionary Word Lists
 
-The default dictionary comes from the permissively licensed **SCOWL** word lists. Files are plain text with one word per line and are loaded into a `Set` for fast filtering.
+The default dictionary comes from the permissively licensed [**SCOWL** word lists](http://wordlist.aspell.net/). Files are plain text with one word per line and are loaded into a `Set` for fast filtering.
 
 ## Development Notes
 
-This is a Next.js project using TypeScript, Tailwind CSS and Vitest. Continuous Integration runs tests and linting on each commit.
+This is a Next.js project using TypeScript, Tailwind CSS and Vitest. Continuous Integration runs tests and linting on each commit. See [ROADMAP.md](ROADMAP.md) for planned tasks.
+
+The project was primarily built using OpenAI Codex Web, OpenAI Codex CLI, Google Gemini CLI and Google Jules.
+
+## License
+
+Released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,10 +50,10 @@ Tasks are only checked when fully complete (tests, docs and lint pass). Keep REA
 - Sort by longest word by default
 
 ### v1.1
-- **TODO** Refactor page components and improve tests. The components have got way too big and complex.
-- **TODO** Ensure switching back and forth between letters and groups persists the groups. Eg if there is a group ABC, then C is excluded, then made available again then it should be in the same group it was before.
-- **TODO** Add a way to make all letters available or unavailable.
-- **TODO** Shift the 2nd and 3rd lines of the keyboard right a bit.
+- Refactored page components and improved tests. The components were too big and complex.
+- Switching back and forth between letters and groups now persists the groups. For example, if there is a group ABC, then C is excluded, then made available again it will remain in the same group.
+- Added a way to make all letters available or unavailable.
+- Shifted the 2nd and 3rd lines of the keyboard right a bit.
 
 ### Offline Support
 - **TODO:** Implement service workers to cache the application

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "letterunbox",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- mark all v1.1 roadmap tasks complete
- link to the SCOWL word list and to ROADMAP from README
- note the tools used in development
- add MIT license section to README and include LICENSE file
- set MIT license field in package.json

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686b7e27866c832bae83b06a3e431177