### PR TITLE
Pin header and keyboard for scrolling results

### DIFF
--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -99,8 +99,10 @@ describe("Home", () => {
     // Check if LetterSelector is rendered (by checking one of its internal elements)
     expect(screen.getByRole("button", { name: "A" })).toBeInTheDocument();
 
-    // Check if WordResults is rendered (by checking the sort dropdown)
-    expect(screen.getByLabelText("Sort:")).toBeInTheDocument();
+    // Check if WordResults is rendered (by checking the no-results message)
+    expect(
+      screen.getByText("No words found for the selected letters.")
+    ).toBeInTheDocument();
   });
 
   it("toggles group view when Groups and Letters buttons are clicked", () => {
@@ -156,6 +158,7 @@ describe("Home", () => {
   it("updates URL fragment with current state", async () => {
     render(<Home wordList={mockWordList} />);
     fireEvent.click(screen.getByRole("button", { name: "A" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open help" }));
     fireEvent.change(screen.getByLabelText("Sort:"), {
       target: { value: "alphabetical-asc" },
     });
@@ -178,6 +181,7 @@ describe("Home", () => {
     render(<Home wordList={mockWordList} />);
     const bBtn = await screen.findByRole("button", { name: "B" });
     expect(bBtn).toHaveClass("border-green-800");
+    fireEvent.click(screen.getByRole("button", { name: "Open help" }));
     expect((screen.getByLabelText("Sort:") as HTMLSelectElement).value).toBe(
       "alphabetical-asc",
     );
@@ -238,6 +242,7 @@ describe("Home", () => {
     fireEvent.click(screen.getByRole("button", { name: "C" }));
     fireEvent.click(screen.getByRole("button", { name: "A" }));
     fireEvent.click(screen.getByRole("button", { name: "T" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open help" }));
     fireEvent.change(screen.getByLabelText("Sort:"), {
       target: { value: "alphabetical-asc" },
     });

--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -94,13 +94,13 @@ describe("Home", () => {
   });
 
   it("passes correct props to LetterSelector and WordResults", () => {
-    const { getByText } = render(<Home wordList={mockWordList} />);
+    render(<Home wordList={mockWordList} />);
 
     // Check if LetterSelector is rendered (by checking one of its internal elements)
     expect(screen.getByRole("button", { name: "A" })).toBeInTheDocument();
 
-    // Check if WordResults is rendered (by checking one of its internal elements)
-    expect(getByText(/Results \(\d+\)/)).toBeInTheDocument();
+    // Check if WordResults is rendered (by checking the sort dropdown)
+    expect(screen.getByLabelText("Sort:")).toBeInTheDocument();
   });
 
   it("toggles group view when Groups and Letters buttons are clicked", () => {

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -82,8 +82,8 @@ export default function Home({ wordList }: HomeProps) {
   };
 
   return (
-    <div className="max-w-3xl mx-auto p-4">
-      <header className="flex items-center justify-between mb-6">
+    <div className="max-w-3xl mx-auto p-4 flex flex-col h-screen">
+      <header className="flex items-center justify-between mb-4 flex-none">
         <h1 className="text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-600">
           Letter Unboxed
         </h1>
@@ -177,29 +177,33 @@ export default function Home({ wordList }: HomeProps) {
           </div>
         </div>
       )}
-      {!showLetterGroups && (
-        <LetterSelector
-          letterStatuses={letterStatuses}
-          onLetterClick={handleLetterClick}
-          onShowGroups={handleShowGroups}
-          onToggleAll={handleToggleAll}
-          toggleAllNext={enableAllNext}
+      <div className="flex-grow overflow-y-auto mb-4">
+        <WordResults
+          results={results}
+          resultCount={results.length}
+          onSortChange={handleSortChange}
+          sortOrder={sortOrder}
         />
-      )}
-      {showLetterGroups && (
-        <LetterGroupsDisplay
-          letterStatuses={letterStatuses}
-          letterGroups={letterGroups}
-          onGroupsChange={setLetterGroups}
-          onShowLetters={() => setShowLetterGroups(false)}
-        />
-      )}
-      <WordResults
-        results={results}
-        resultCount={results.length}
-        onSortChange={handleSortChange}
-        sortOrder={sortOrder}
-      />
+      </div>
+      <div className="flex-none">
+        {!showLetterGroups && (
+          <LetterSelector
+            letterStatuses={letterStatuses}
+            onLetterClick={handleLetterClick}
+            onShowGroups={handleShowGroups}
+            onToggleAll={handleToggleAll}
+            toggleAllNext={enableAllNext}
+          />
+        )}
+        {showLetterGroups && (
+          <LetterGroupsDisplay
+            letterStatuses={letterStatuses}
+            letterGroups={letterGroups}
+            onGroupsChange={setLetterGroups}
+            onShowLetters={() => setShowLetterGroups(false)}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -82,7 +82,7 @@ export default function Home({ wordList }: HomeProps) {
   };
 
   return (
-    <div className="max-w-3xl mx-auto p-4 flex flex-col h-screen gap-4">
+    <div className="max-w-3xl mx-auto p-4 flex flex-col h-dvh overflow-hidden gap-4">
       <header className="flex items-center justify-between flex-none">
         <h1 className="text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-600">
           Letter Unboxed
@@ -134,6 +134,28 @@ export default function Home({ wordList }: HomeProps) {
               <p>
                 Drag letters into groups to stop them being used consecutively.
               </p>
+              <div className="flex items-center space-x-2">
+                <label htmlFor="sortOrder" className="text-sm">Sort:</label>
+                <select
+                  id="sortOrder"
+                  value={sortOrder}
+                  onChange={(e) =>
+                    handleSortChange(
+                      e.target.value as
+                        | 'alphabetical-asc'
+                        | 'alphabetical-desc'
+                        | 'length-asc'
+                        | 'length-desc'
+                    )
+                  }
+                  className="px-2 py-1 border border-gray-400 rounded-md text-sm"
+                >
+                  <option value="alphabetical-asc">A-Z</option>
+                  <option value="alphabetical-desc">Z-A</option>
+                  <option value="length-asc">Shortest</option>
+                  <option value="length-desc">Longest</option>
+                </select>
+              </div>
               <p>
                 <a
                   href="https://dave.engineer"
@@ -178,11 +200,7 @@ export default function Home({ wordList }: HomeProps) {
         </div>
       )}
       <div className="flex-grow overflow-y-auto">
-        <WordResults
-          results={results}
-          onSortChange={handleSortChange}
-          sortOrder={sortOrder}
-        />
+        <WordResults results={results} />
       </div>
       <div className="flex-none">
         {!showLetterGroups && (

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -82,8 +82,8 @@ export default function Home({ wordList }: HomeProps) {
   };
 
   return (
-    <div className="max-w-3xl mx-auto p-4 flex flex-col h-screen">
-      <header className="flex items-center justify-between mb-4 flex-none">
+    <div className="max-w-3xl mx-auto p-4 flex flex-col h-screen gap-4">
+      <header className="flex items-center justify-between flex-none">
         <h1 className="text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-600">
           Letter Unboxed
         </h1>
@@ -177,10 +177,9 @@ export default function Home({ wordList }: HomeProps) {
           </div>
         </div>
       )}
-      <div className="flex-grow overflow-y-auto mb-4">
+      <div className="flex-grow overflow-y-auto">
         <WordResults
           results={results}
-          resultCount={results.length}
           onSortChange={handleSortChange}
           sortOrder={sortOrder}
         />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white bg-[length:200%_200%] animate-gradient">{children}</body>
+      <body className="min-h-dvh bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white bg-[length:200%_200%] animate-gradient">{children}</body>
     </html>
   )
 }

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -51,7 +51,7 @@ const WordResults: React.FC<WordResultsProps> = ({
           No words found for the selected letters.
         </p>
       )}
-      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 max-h-96 overflow-y-auto border border-gray-600 p-2 rounded-md bg-gray-800/50">
+      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 overflow-y-auto border border-gray-600 p-2 rounded-md bg-gray-800/50">
         {results.map((word) => (
           <li
             key={word}

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -8,41 +8,14 @@ export type SortOrder =
 
 interface WordResultsProps {
   results: string[];
-  onSortChange?: (sortOrder: SortOrder) => void;
-  sortOrder?: SortOrder;
 }
 
 const WordResults: React.FC<WordResultsProps> = ({
   results,
-  onSortChange = () => {},
-  sortOrder = 'alphabetical-asc',
 }) => {
   return (
     <div className="border-t border-gray-600 pt-5">
-      <div className="flex justify-end mb-4">
-        <div className="flex items-center space-x-2">
-          <label htmlFor="sortOrder" className="text-sm text-gray-300">Sort:</label>
-        <select
-          id="sortOrder"
-          value={sortOrder}
-          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-            onSortChange(
-              e.target.value as
-                | 'alphabetical-asc'
-                | 'alphabetical-desc'
-                | 'length-asc'
-                | 'length-desc'
-            )
-          }
-          className="px-2 py-1 border border-gray-600 rounded-md bg-gray-800 text-sm text-white"
-        >
-            <option value="alphabetical-asc">A-Z</option>
-            <option value="alphabetical-desc">Z-A</option>
-            <option value="length-asc">Shortest</option>
-            <option value="length-desc">Longest</option>
-          </select>
-        </div>
-      </div>
+      <div className="mb-4" />
       {results.length === 0 && (
         <p className="text-center text-gray-400">
           No words found for the selected letters.

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -8,21 +8,18 @@ export type SortOrder =
 
 interface WordResultsProps {
   results: string[];
-  resultCount?: number;
   onSortChange?: (sortOrder: SortOrder) => void;
   sortOrder?: SortOrder;
 }
 
 const WordResults: React.FC<WordResultsProps> = ({
   results,
-  resultCount = results.length,
   onSortChange = () => {},
   sortOrder = 'alphabetical-asc',
 }) => {
   return (
     <div className="border-t border-gray-600 pt-5">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-semibold text-gray-200">Results ({resultCount})</h2>
+      <div className="flex justify-end mb-4">
         <div className="flex items-center space-x-2">
           <label htmlFor="sortOrder" className="text-sm text-gray-300">Sort:</label>
         <select


### PR DESCRIPTION
## Summary
- keep header, keyboard, and groups fixed using flex layout
- allow results to scroll between them

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c068160c8832bb9a8a2ec050568b7