### PR TITLE
Improve empty results prompt

### DIFF
--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -64,9 +64,11 @@ describe("Home", () => {
   it("filters words based on letter status changes", async () => {
     render(<Home wordList={mockWordList} />);
 
-    // Initially, no words should be found as all letters are unavailable
+    // Initially, a prompt should show as no letters are selected
     expect(
-      screen.getByText("No words found for the selected letters."),
+      screen.getByText(
+        "Tap letters to make them available. Tap again to require words to use them at the start, anywhere in the word or at the end.",
+      ),
     ).toBeInTheDocument();
 
     // Click 'C' to make it available
@@ -99,9 +101,11 @@ describe("Home", () => {
     // Check if LetterSelector is rendered (by checking one of its internal elements)
     expect(screen.getByRole("button", { name: "A" })).toBeInTheDocument();
 
-    // Check if WordResults is rendered (by checking the no-results message)
+    // Check if WordResults is rendered (by checking the prompt message)
     expect(
-      screen.getByText("No words found for the selected letters.")
+      screen.getByText(
+        "Tap letters to make them available. Tap again to require words to use them at the start, anywhere in the word or at the end."
+      )
     ).toBeInTheDocument();
   });
 

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -200,7 +200,13 @@ export default function Home({ wordList }: HomeProps) {
         </div>
       )}
       <div className="flex-grow overflow-y-auto">
-        <WordResults results={results} />
+        <WordResults
+          results={results}
+          lettersSelected={Object.values(letterStatuses).some(
+            (status) =>
+              status === "available" || status.startsWith("required")
+          )}
+        />
       </div>
       <div className="flex-none">
         {!showLetterGroups && (

--- a/src/components/WordResults.test.tsx
+++ b/src/components/WordResults.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect } from 'vitest';
 describe('WordResults', () => {
   it('renders a list of words when provided', () => {
     const words = ['apple', 'banana', 'cherry'];
-    render(<WordResults results={words} />);
+    render(<WordResults results={words} lettersSelected={true} />);
 
     expect(screen.getByText('apple')).toBeInTheDocument();
     expect(screen.getByText('banana')).toBeInTheDocument();
@@ -14,10 +14,20 @@ describe('WordResults', () => {
   });
 
   it('displays a message when no words are found', () => {
-    render(<WordResults results={[]} />);
+    render(<WordResults results={[]} lettersSelected={true} />);
 
     expect(screen.getByText('No words found for the selected letters.')).toBeInTheDocument();
     expect(screen.queryByText('apple')).not.toBeInTheDocument();
+  });
+
+  it('prompts to select letters when none are available', () => {
+    render(<WordResults results={[]} lettersSelected={false} />);
+
+    expect(
+      screen.getByText(
+        'Tap letters to make them available. Tap again to require words to use them at the start, anywhere in the word or at the end.',
+      ),
+    ).toBeInTheDocument();
   });
 
   

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -8,29 +8,33 @@ export type SortOrder =
 
 interface WordResultsProps {
   results: string[];
+  lettersSelected: boolean;
 }
 
-const WordResults: React.FC<WordResultsProps> = ({
-  results,
-}) => {
+const WordResults: React.FC<WordResultsProps> = ({ results, lettersSelected }) => {
+  const noLettersMessage =
+    "Tap letters to make them available. Tap again to require words to use them at the start, anywhere in the word or at the end.";
+  const noWordsMessage = "No words found for the selected letters.";
   return (
-    <div className="border-t border-gray-600 pt-5">
-      <div className="mb-4" />
-      {results.length === 0 && (
-        <p className="text-center text-gray-400">
-          No words found for the selected letters.
-        </p>
+    <div className="border-t border-gray-600 pt-5 h-full flex flex-col">
+      {results.length === 0 ? (
+        <div className="flex-grow flex items-center justify-center">
+          <p className="text-center text-gray-400 px-4">
+            {lettersSelected ? noWordsMessage : noLettersMessage}
+          </p>
+        </div>
+      ) : (
+        <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 overflow-y-auto border border-gray-600 p-2 rounded-md bg-gray-800/50">
+          {results.map((word) => (
+            <li
+              key={word}
+              className="bg-gray-700 border border-gray-600 rounded-md p-2 text-center shadow-sm text-white"
+            >
+              {word}
+            </li>
+          ))}
+        </ul>
       )}
-      <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 overflow-y-auto border border-gray-600 p-2 rounded-md bg-gray-800/50">
-        {results.map((word) => (
-          <li
-            key={word}
-            className="bg-gray-700 border border-gray-600 rounded-md p-2 text-center shadow-sm text-white"
-          >
-            {word}
-          </li>
-        ))}
-      </ul>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- display a helpful prompt when no letters are selected
- center the empty state message
- adjust tests for new behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c119ff648832ba4175bd7f0fa6af0