### PR TITLE
Update word results and styled heading

### DIFF
--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -43,7 +43,7 @@ describe("Home", () => {
 
   it("renders the main heading", () => {
     render(<Home wordList={mockWordList} />);
-    expect(screen.getByText("Letter Unboxed")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
   });
 
   it("initializes letter statuses to unavailable", () => {
@@ -65,9 +65,10 @@ describe("Home", () => {
     render(<Home wordList={mockWordList} />);
 
     // Initially, a prompt should show as no letters are selected
+    expect(screen.getByText('Tap letters to make them available.')).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Tap letters to make them available. Tap again to require words to use them at the start, anywhere in the word or at the end.",
+        'Tap again to require words to use them at the start, anywhere in the word or at the end.',
       ),
     ).toBeInTheDocument();
 
@@ -102,9 +103,10 @@ describe("Home", () => {
     expect(screen.getByRole("button", { name: "A" })).toBeInTheDocument();
 
     // Check if WordResults is rendered (by checking the prompt message)
+    expect(screen.getByText('Tap letters to make them available.')).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Tap letters to make them available. Tap again to require words to use them at the start, anywhere in the word or at the end."
+        'Tap again to require words to use them at the start, anywhere in the word or at the end.'
       )
     ).toBeInTheDocument();
   });

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -83,38 +83,40 @@ export default function Home({ wordList }: HomeProps) {
   };
 
   return (
-    <div className="max-w-3xl mx-auto p-4 flex flex-col h-dvh overflow-hidden gap-2">
-      <header className="flex items-center justify-between flex-none py-1">
-        <h1 className="flex flex-col items-center text-3xl font-bold gap-1">
-          <div className="flex gap-1">
+    <div className="max-w-3xl mx-auto p-2 flex flex-col h-dvh overflow-hidden gap-1">
+      <header className="flex items-center justify-between flex-none py-0.5">
+        <h1 className="flex flex-col items-center text-2xl font-bold gap-0.5">
+          <div className="flex gap-0.5">
             {"LETTER".split("").map((ch, i) => (
               <span
                 key={i}
-                className={getLetterButtonClasses(
+                className={`${getLetterButtonClasses(
                   ch === "L"
                     ? "required-start"
                     : ch === "R"
                     ? "required-end"
                     : "available",
                   false,
-                )}
+                  true,
+                )} w-6 inline-flex items-center justify-center`}
               >
                 {ch}
               </span>
             ))}
           </div>
-          <div className="flex gap-1">
-            {"BOXED".split("").map((ch, i) => (
+          <div className="flex gap-0.5">
+            {"UNBOXED".split("").map((ch, i) => (
               <span
                 key={i}
-                className={getLetterButtonClasses(
+                className={`${getLetterButtonClasses(
                   ch === "D"
                     ? "required-end"
                     : ch === "X"
                     ? "required-anywhere"
                     : "available",
                   false,
-                )}
+                  true,
+                )} w-6 inline-flex items-center justify-center`}
               >
                 {ch}
               </span>
@@ -124,7 +126,7 @@ export default function Home({ wordList }: HomeProps) {
         <button
           aria-label={showHelp ? "Close help" : "Open help"}
           onClick={() => setShowHelp(!showHelp)}
-          className={`${getLetterButtonClasses('excluded')} h-10 w-10 flex items-center justify-center`}
+          className={`${getLetterButtonClasses('excluded', false, true)} w-8 h-8 flex items-center justify-center`}
         >
           ?
         </button>

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -6,6 +6,7 @@ import LetterSelector from "../components/LetterSelector";
 import WordResults, { SortOrder } from "../components/WordResults";
 import LetterGroupsDisplay from "../components/LetterGroupsDisplay";
 import type { LetterStatus } from "../components/letterStyles";
+import { getLetterButtonClasses } from "../components/letterStyles";
 import { encodeState, decodeState } from "../lib/urlState";
 import {
   computeResults,
@@ -82,15 +83,48 @@ export default function Home({ wordList }: HomeProps) {
   };
 
   return (
-    <div className="max-w-3xl mx-auto p-4 flex flex-col h-dvh overflow-hidden gap-4">
-      <header className="flex items-center justify-between flex-none">
-        <h1 className="text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-600">
-          Letter Unboxed
+    <div className="max-w-3xl mx-auto p-4 flex flex-col h-dvh overflow-hidden gap-2">
+      <header className="flex items-center justify-between flex-none py-1">
+        <h1 className="flex flex-col items-center text-3xl font-bold gap-1">
+          <div className="flex gap-1">
+            {"LETTER".split("").map((ch, i) => (
+              <span
+                key={i}
+                className={getLetterButtonClasses(
+                  ch === "L"
+                    ? "required-start"
+                    : ch === "R"
+                    ? "required-end"
+                    : "available",
+                  false,
+                )}
+              >
+                {ch}
+              </span>
+            ))}
+          </div>
+          <div className="flex gap-1">
+            {"BOXED".split("").map((ch, i) => (
+              <span
+                key={i}
+                className={getLetterButtonClasses(
+                  ch === "D"
+                    ? "required-end"
+                    : ch === "X"
+                    ? "required-anywhere"
+                    : "available",
+                  false,
+                )}
+              >
+                {ch}
+              </span>
+            ))}
+          </div>
         </h1>
         <button
           aria-label={showHelp ? "Close help" : "Open help"}
           onClick={() => setShowHelp(!showHelp)}
-          className="text-white bg-blue-600 hover:bg-blue-700 h-10 w-10 flex items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className={`${getLetterButtonClasses('excluded')} h-10 w-10 flex items-center justify-center`}
         >
           ?
         </button>

--- a/src/components/WordResults.test.tsx
+++ b/src/components/WordResults.test.tsx
@@ -24,8 +24,11 @@ describe('WordResults', () => {
     render(<WordResults results={[]} lettersSelected={false} />);
 
     expect(
+      screen.getByText('Tap letters to make them available.'),
+    ).toBeInTheDocument();
+    expect(
       screen.getByText(
-        'Tap letters to make them available. Tap again to require words to use them at the start, anywhere in the word or at the end.',
+        'Tap again to require words to use them at the start, anywhere in the word or at the end.',
       ),
     ).toBeInTheDocument();
   });

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -12,19 +12,26 @@ interface WordResultsProps {
 }
 
 const WordResults: React.FC<WordResultsProps> = ({ results, lettersSelected }) => {
-  const noLettersMessage =
-    "Tap letters to make them available. Tap again to require words to use them at the start, anywhere in the word or at the end.";
+  const noLettersMessagePart1 =
+    "Tap letters to make them available.";
+  const noLettersMessagePart2 =
+    "Tap again to require words to use them at the start, anywhere in the word or at the end.";
   const noWordsMessage = "No words found for the selected letters.";
   return (
-    <div className="border-t border-gray-600 pt-5 h-full flex flex-col">
+    <div className="pt-5 h-full flex flex-col">
       {results.length === 0 ? (
         <div className="flex-grow flex items-center justify-center">
-          <p className="text-center text-gray-400 px-4">
-            {lettersSelected ? noWordsMessage : noLettersMessage}
-          </p>
+          {lettersSelected ? (
+            <p className="text-center text-gray-400 px-4">{noWordsMessage}</p>
+          ) : (
+            <div className="text-center text-gray-400 px-4 space-y-2">
+              <p>{noLettersMessagePart1}</p>
+              <p>{noLettersMessagePart2}</p>
+            </div>
+          )}
         </div>
       ) : (
-        <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 overflow-y-auto border border-gray-600 p-2 rounded-md bg-gray-800/50">
+        <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 overflow-y-auto p-2 rounded-md bg-gray-800/50">
           {results.map((word) => (
             <li
               key={word}

--- a/src/components/letterStyles.ts
+++ b/src/components/letterStyles.ts
@@ -1,7 +1,12 @@
 export type LetterStatus = 'available' | 'required-start' | 'required-anywhere' | 'required-end' | 'excluded';
 
-export function getLetterButtonClasses(status: LetterStatus, interactive = true): string {
-  const base = `py-2 text-lg font-bold rounded transition border-2 shadow-md${interactive ? ' hover:scale-105' : ''}`;
+export function getLetterButtonClasses(
+  status: LetterStatus,
+  interactive = true,
+  compact = false,
+): string {
+  const sizeClasses = compact ? 'py-1 text-sm' : 'py-2 text-lg';
+  const base = `${sizeClasses} font-bold rounded transition border-2 shadow-md${interactive ? ' hover:scale-105' : ''}`;
   const alignClass =
     status === 'required-start'
       ? 'text-left pl-0'


### PR DESCRIPTION
## Summary
- make WordResults text more readable
- show LETTER BOXED heading with styled letters
- tidy up tests for updated markup

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686c175efc5c832bb426bfd4196957df