### PR TITLE
Decrease font size for long words

### DIFF
--- a/src/components/WordResults.test.tsx
+++ b/src/components/WordResults.test.tsx
@@ -30,5 +30,13 @@ describe('WordResults', () => {
     ).toBeInTheDocument();
   });
 
+  it('uses smaller text for words 15 characters or longer', () => {
+    const words = ['short', 'averyverylonglongword'];
+    render(<WordResults results={words} lettersSelected={true} />);
+
+    expect(screen.getByText('averyverylonglongword')).toHaveClass('text-sm');
+    expect(screen.getByText('short')).not.toHaveClass('text-sm');
+  });
+
   
 });

--- a/src/components/WordResults.tsx
+++ b/src/components/WordResults.tsx
@@ -25,14 +25,17 @@ const WordResults: React.FC<WordResultsProps> = ({ results, lettersSelected }) =
         </div>
       ) : (
         <ul className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 overflow-y-auto border border-gray-600 p-2 rounded-md bg-gray-800/50">
-          {results.map((word) => (
-            <li
-              key={word}
-              className="bg-gray-700 border border-gray-600 rounded-md p-2 text-center shadow-sm text-white"
-            >
-              {word}
-            </li>
-          ))}
+          {results.map((word) => {
+            const longWord = word.length >= 15;
+            return (
+              <li
+                key={word}
+                className={`bg-gray-700 border border-gray-600 rounded-md p-2 text-center shadow-sm text-white${longWord ? ' text-sm' : ''}`}
+              >
+                {word}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>


### PR DESCRIPTION
## Summary
- reduce font size for long words in `WordResults`
- test that long words get the `text-sm` class

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c19105ef0832b81c467fc70f0427f