### PR TITLE
Clear groups on 🧹

### DIFF
--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -161,6 +161,25 @@ describe("Home", () => {
     expect(screen.getByRole("button", { name: "A" })).toHaveClass("border-gray-700");
   });
 
+  it("clears letter groups when clearing all letters", () => {
+    render(<Home wordList={mockWordList} />);
+    fireEvent.click(screen.getByRole("button", { name: "A" }));
+    fireEvent.click(screen.getByRole("button", { name: "B" }));
+    fireEvent.click(screen.getByRole("button", { name: "Groups" }));
+    let letters = screen
+      .getAllByRole("button")
+      .filter((btn) => /^[A-Z]$/.test(btn.textContent || ""));
+    expect(letters.map((btn) => btn.textContent)).toEqual(["A", "B"]);
+    fireEvent.click(screen.getByRole("button", { name: "Letters" }));
+    fireEvent.click(screen.getByRole("button", { name: "Enable all letters" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear all letters" }));
+    fireEvent.click(screen.getByRole("button", { name: "Groups" }));
+    letters = screen
+      .getAllByRole("button")
+      .filter((btn) => /^[A-Z]$/.test(btn.textContent || ""));
+    expect(letters).toEqual([]);
+  });
+
   it("updates URL fragment with current state", async () => {
     render(<Home wordList={mockWordList} />);
     fireEvent.click(screen.getByRole("button", { name: "A" }));

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -70,6 +70,9 @@ export default function Home({ wordList }: HomeProps) {
       });
       return updated;
     });
+    if (!enableAllNext) {
+      setLetterGroups('');
+    }
     setEnableAllNext(!enableAllNext);
   };
 


### PR DESCRIPTION
## Summary
- clear groups when using the 🧹 button
- test group clearing

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c473db58c832bbf9c8bffb358fa02