### PR TITLE
Add cheat search for word pairs

### DIFF
--- a/src/app/home-client.test.tsx
+++ b/src/app/home-client.test.tsx
@@ -149,6 +149,20 @@ describe("Home", () => {
     expect(letters).toEqual(["A", "B", "C"]);
   });
 
+  it("shows Cheat button in group view and alerts pairs", () => {
+    const words = ["abc", "cdefghijkl"];
+    render(<Home wordList={words} />);
+    "abcdefghijkl".split("").forEach((l) => {
+      fireEvent.click(screen.getByRole("button", { name: l.toUpperCase() }));
+    });
+    const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+    fireEvent.click(screen.getByRole("button", { name: "Groups" }));
+    const cheatBtn = screen.getByRole("button", { name: "Cheat" });
+    fireEvent.click(cheatBtn);
+    expect(alertMock).toHaveBeenCalledWith("abc cdefghijkl");
+    alertMock.mockRestore();
+  });
+
   it("toggles all letters available and back", () => {
     render(<Home wordList={mockWordList} />);
     const toggle = screen.getByRole("button", { name: "Enable all letters" });

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -13,6 +13,7 @@ import {
   createDefaultStatuses,
   cycleMap,
   calculateGroups,
+  findCheatPairs,
 } from "./home-utils";
 
 interface HomeProps {
@@ -83,6 +84,15 @@ export default function Home({ wordList }: HomeProps) {
   const handleShowGroups = () => {
     setLetterGroups(calculateGroups(letterStatuses, letterGroups));
     setShowLetterGroups(true);
+  };
+
+  const handleCheat = () => {
+    const pairs = findCheatPairs(dictionary, letterStatuses, letterGroups);
+    if (pairs.length) {
+      alert(pairs.join('\n'));
+    } else {
+      alert('No pairs found');
+    }
   };
 
   return (
@@ -263,6 +273,7 @@ export default function Home({ wordList }: HomeProps) {
             letterGroups={letterGroups}
             onGroupsChange={setLetterGroups}
             onShowLetters={() => setShowLetterGroups(false)}
+            onCheat={handleCheat}
           />
         )}
       </div>

--- a/src/app/home-utils.test.ts
+++ b/src/app/home-utils.test.ts
@@ -5,6 +5,7 @@ import {
   cycleMap,
   computeResults,
   calculateGroups,
+  findCheatPairs,
 } from "./home-utils";
 import type { LetterStatus } from "../components/letterStyles";
 
@@ -46,5 +47,15 @@ describe("home-utils", () => {
     statuses.c = "available";
     groups = calculateGroups(statuses, "ab,cd");
     expect(groups).toBe("ab,c");
+  });
+
+  it("findCheatPairs finds word pairs using all letters", () => {
+    const dict = new Dictionary("abc", "cdefghijkl", "xyz");
+    const statuses = createDefaultStatuses();
+    "abcdefghijkl".split("").forEach((c) => {
+      statuses[c] = "available";
+    });
+    const pairs = findCheatPairs(dict, statuses, "");
+    expect(pairs).toEqual(["abc cdefghijkl"]);
   });
 });

--- a/src/app/home-utils.ts
+++ b/src/app/home-utils.ts
@@ -106,3 +106,59 @@ export function calculateGroups(
 
   return groups.join(",");
 }
+
+export function findCheatPairs(
+  dictionary: Dictionary | null,
+  letterStatuses: Record<string, LetterStatus>,
+  letterGroups: string,
+): string[] {
+  if (!dictionary) return [];
+
+  const availableLetters = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "available")
+    .join("");
+  const requiredAnywhere = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "required-anywhere")
+    .join("");
+  const requiredStart = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "required-start")
+    .join("");
+  const requiredEnd = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "required-end")
+    .join("");
+  const excludedLetters = Object.keys(letterStatuses)
+    .filter((char) => letterStatuses[char] === "excluded")
+    .join("");
+
+  const filtered = dictionary.filter(
+    availableLetters,
+    requiredAnywhere + requiredStart + requiredEnd,
+    excludedLetters,
+    requiredStart,
+    requiredEnd,
+    letterGroups,
+  );
+
+  const selectedLetters = (
+    availableLetters + requiredAnywhere + requiredStart + requiredEnd
+  ).split("");
+  const selectedSet = new Set(selectedLetters);
+
+  const pairs: string[] = [];
+  for (const w1 of filtered) {
+    for (const w2 of filtered) {
+      if (w1[w1.length - 1] !== w2[0]) continue;
+      if (w1.length + w2.length < 12) continue;
+      const combined = w1 + w2;
+      let usesAll = true;
+      for (const ch of selectedSet) {
+        if (!combined.includes(ch)) {
+          usesAll = false;
+          break;
+        }
+      }
+      if (usesAll) pairs.push(`${w1} ${w2}`);
+    }
+  }
+  return pairs;
+}

--- a/src/components/LetterGroupsDisplay.tsx
+++ b/src/components/LetterGroupsDisplay.tsx
@@ -19,6 +19,7 @@ interface LetterGroupsDisplayProps {
   letterGroups: string;
   onGroupsChange: (groups: string) => void;
   onShowLetters: () => void;
+  onCheat?: () => void;
 }
 
 function DraggableLetter({ char, groupIndex, status }: { char: string; groupIndex: number; status: LetterStatus }) {
@@ -72,6 +73,7 @@ const LetterGroupsDisplay: React.FC<LetterGroupsDisplayProps> = ({
   letterGroups,
   onGroupsChange,
   onShowLetters,
+  onCheat,
 }) => {
   const groups = letterGroups ? letterGroups.split(',').filter(Boolean) : [];
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 0 } }));
@@ -123,6 +125,14 @@ const LetterGroupsDisplay: React.FC<LetterGroupsDisplayProps> = ({
         >
           Letters
         </button>
+        {onCheat && (
+          <button
+            onClick={onCheat}
+            className="py-2 px-4 text-lg font-bold rounded transition border-2 shadow-md hover:scale-105 bg-gray-600 text-gray-300 border-gray-700"
+          >
+            Cheat
+          </button>
+        )}
       </div>
       <DragOverlay>
         {activeChar ? (


### PR DESCRIPTION
## Summary
- add `findCheatPairs` helper
- add Cheat button next to Letters button
- show alert with found pairs
- test cheat search functionality

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d0ee8c054832bae1abe0c4fb3f97e